### PR TITLE
fix: stop injecting defer-hydration attribute during SSR

### DIFF
--- a/pkg/transformer/render.go
+++ b/pkg/transformer/render.go
@@ -236,10 +236,6 @@ func renderHTMLBatched(doc *html.Node, ctx *transformContext, maxDepth int) erro
 				templateNode.AppendChild(sn)
 			}
 
-			if depth > 0 {
-				p.node.Attr = append(p.node.Attr, html.Attribute{Key: "defer-hydration"})
-			}
-
 			if p.node.FirstChild != nil {
 				p.node.InsertBefore(templateNode, p.node.FirstChild)
 			} else {

--- a/pkg/transformer/render_test.go
+++ b/pkg/transformer/render_test.go
@@ -193,7 +193,7 @@ func TestRenderFragment_UnregisteredElement(t *testing.T) {
 	}
 }
 
-func TestRenderFragment_NestedElements_DeferHydration(t *testing.T) {
+func TestRenderFragment_NestedElements_NoDeferHydration(t *testing.T) {
 	engine := newMockEngine()
 	engine.addComponent("outer-el", `<inner-el></inner-el>`, "")
 	engine.addComponent("inner-el", "<p>nested</p>", "")
@@ -208,11 +208,34 @@ func TestRenderFragment_NestedElements_DeferHydration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(output, "defer-hydration") {
-		t.Error("nested element should have defer-hydration attribute")
+	if strings.Contains(output, "defer-hydration") {
+		t.Error("golit should not inject defer-hydration; it is an opt-in attribute for developers")
 	}
 	if !strings.Contains(output, "<p>nested</p>") {
 		t.Error("nested element should be rendered")
+	}
+}
+
+func TestRenderFragment_LightDOMChildren_NoDeferHydration(t *testing.T) {
+	engine := newMockEngine()
+	engine.addComponent("parent-el", `<slot></slot>`, "")
+	engine.addComponent("child-el", "<p>child</p>", "")
+
+	registry := jsengine.NewRegistry()
+	registry.Register("parent-el", "fake-bundle")
+	registry.Register("child-el", "fake-bundle")
+
+	output, err := RenderFragmentWithEngine(
+		`<parent-el><child-el></child-el></parent-el>`, engine, registry, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(output, `child-el defer-hydration`) {
+		t.Error("light DOM child element should not have defer-hydration")
+	}
+	if !strings.Contains(output, "<p>child</p>") {
+		t.Error("light DOM child should still be rendered")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Removes automatic `defer-hydration` injection from `renderHTMLBatched` in the SSR transformer
- `defer-hydration` is an opt-in performance attribute that developers control — golit should not inject it automatically
- The previous behavior added `defer-hydration` to all elements discovered after the first BFS pass (depth > 0), which broke hydration for light DOM children (e.g. `rh-accordion-panel`, `rh-tab-panel`, `rh-progress-step`) since Lit's hydration protocol only cascades `defer-hydration` removal through shadow roots, not the light DOM

## Test plan
- [x] Existing test updated: `TestRenderFragment_NestedElements_NoDeferHydration` verifies shadow DOM children no longer get `defer-hydration`
- [x] New test: `TestRenderFragment_LightDOMChildren_NoDeferHydration` verifies light DOM children don't get `defer-hydration`
- [x] Full test suite passes (`go test ./...`)
- [ ] Rebuild hugo-rhds example and verify accordion panels, tab panels, and other previously broken components now hydrate and respond to interaction

Made with [Cursor](https://cursor.com)