### PR TITLE
feat(jsengine): SSR fetch bridge and Lit-aligned domshim globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ If **`GOLIT_SERVE_URL`** is **unset**, the examples fall back to running **`goli
 | **`GOLIT_BIN`** | Path to `golit` binary for the cold path only. |
 | **`GOLIT_DISABLED`** | If set (e.g. `1`), skip SSR and serve untransformed HTML (used by benchmarks for A/B comparison). |
 
+QuickJS SSR (used by **`golit transform`** and **`golit serve`** rendering) exposes **`globalThis.fetch`** backed by Go **`net/http`** (similar in spirit to **`@lit/ssr`** + **`node-fetch`**). **`matchMedia`** is not defined server-side (viewport-only).
+
+| Variable | Purpose |
+| -------- | -------- |
+| **`GOLIT_SSR_LOCATION`** | Base URL string for **`globalThis.location`** (default **`http://localhost/`**), aligned with Lit’s **`getWindow()`** default. |
+| **`GOLIT_FETCH_ALLOWLIST`** | Optional comma-separated **hostnames** (no scheme/port). If set, **`fetch`** may only request those hosts (mitigates SSRF). If unset, only **`http:`** / **`https:`** are allowed. |
+| **`GOLIT_FETCH_TIMEOUT_SEC`** | Per-request timeout in seconds (default **10**, clamped). |
+| **`GOLIT_FETCH_MAX_BODY_BYTES`** | Max response body bytes read (default **16 MiB**, capped). |
+
+After upgrading golit, regenerate pre-bundled defs (e.g. **`make bundle`** in **`examples/hugo-rhds`**) so injected **`domshim.js`** matches the new binary.
+
 ### PHP example
 
 **Prerequisites:** Go (to build golit from this repo), PHP 8+, Node/npm for `npm install` during `make build`.

--- a/examples/hugo-rhds/golit.yaml
+++ b/examples/hugo-rhds/golit.yaml
@@ -1,6 +1,7 @@
 transform:
   defs: bundles/
   verbose: true
+  concurrency: true
   preload:
     - prism-esm
   ignore:

--- a/pkg/jsengine/domshim.js
+++ b/pkg/jsengine/domshim.js
@@ -304,5 +304,188 @@ globalThis.__registerPreload = function(name, exports) {
   globalThis.__preloadedModules[name] = exports;
 };
 
+// --- SSR URL / location (align with @lit/ssr getWindow: stable base URL) ---
+// matchMedia is intentionally not shimmed (viewport-specific; no server semantics).
+
+(function () {
+  const base = typeof globalThis.__golitLocationHref === 'string'
+    ? globalThis.__golitLocationHref
+    : 'http://localhost/';
+  try {
+    globalThis.location ??= new URL(base);
+  } catch (_) {
+    globalThis.location ??= {
+      href: base,
+      origin: '',
+      protocol: 'http:',
+      host: 'localhost',
+      hostname: 'localhost',
+      port: '',
+      pathname: '/',
+      search: '',
+      hash: '',
+      assign() {},
+      replace() {},
+      reload() {},
+      toString() { return this.href; },
+    };
+  }
+})();
+
+globalThis.URLSearchParams ??= class URLSearchParams {
+  constructor(init) {
+    this._map = new Map();
+    if (init == null || init === '') return;
+    if (typeof init === 'string') {
+      let s = init.startsWith('?') ? init.slice(1) : init;
+      for (const pair of s.split('&')) {
+        if (!pair) continue;
+        const i = pair.indexOf('=');
+        const k = i >= 0 ? pair.slice(0, i) : pair;
+        const v = i >= 0 ? pair.slice(i + 1) : '';
+        try {
+          this._map.set(decodeURIComponent(k), decodeURIComponent(v));
+        } catch (_) {
+          this._map.set(k, v);
+        }
+      }
+    } else if (typeof init === 'object') {
+      for (const key of Object.keys(init)) {
+        this._map.set(key, String(init[key]));
+      }
+    }
+  }
+  get(k) { return this._map.has(k) ? this._map.get(k) : null; }
+  set(k, v) { this._map.set(String(k), String(v)); }
+  has(k) { return this._map.has(k); }
+  append(k, v) {
+    const key = String(k);
+    const cur = this._map.get(key);
+    this._map.set(key, cur == null ? String(v) : cur + ',' + String(v));
+  }
+  toString() {
+    const parts = [];
+    for (const [k, v] of this._map) {
+      parts.push(encodeURIComponent(k) + '=' + encodeURIComponent(v));
+    }
+    return parts.join('&');
+  }
+};
+
+if (typeof globalThis.URL === 'undefined') {
+  globalThis.URL = class URL {
+    constructor(url, base) {
+      let s = String(url);
+      if (base != null && base !== '') {
+        const b = String(base).replace(/\/+$/, '');
+        s = s.startsWith('/') ? b + s : b + '/' + s.replace(/^\/+/, '');
+      }
+      this.href = s;
+    }
+    toString() { return this.href; }
+    get pathname() {
+      const q = this.href.indexOf('?');
+      const h = this.href.indexOf('#');
+      const end = q >= 0 && h >= 0 ? Math.min(q, h) : (q >= 0 ? q : (h >= 0 ? h : this.href.length));
+      const start = this.href.indexOf('/', this.href.indexOf('//') + 2);
+      if (start < 0) return '/';
+      const p = this.href.slice(start, end);
+      return p || '/';
+    }
+    get search() {
+      const q = this.href.indexOf('?');
+      if (q < 0) return '';
+      const h = this.href.indexOf('#', q);
+      return h >= 0 ? this.href.slice(q, h) : this.href.slice(q);
+    }
+    get hash() {
+      const h = this.href.indexOf('#');
+      return h >= 0 ? this.href.slice(h) : '';
+    }
+    get host() {
+      const m = this.href.match(/^https?:\/\/([^/?#]+)/i);
+      return m ? m[1] : '';
+    }
+    get hostname() { return this.host.split(':')[0]; }
+    get port() {
+      const h = this.host;
+      const i = h.lastIndexOf(':');
+      return i > 0 && /^\d+$/.test(h.slice(i + 1)) ? h.slice(i + 1) : '';
+    }
+    get protocol() {
+      const m = this.href.match(/^([a-z]+:)/i);
+      return m ? m[1].toLowerCase() : 'http:';
+    }
+    get origin() {
+      const m = this.href.match(/^(https?:\/\/[^/?#]+)/i);
+      return m ? m[1] : '';
+    }
+  };
+}
+
+(function () {
+  if (typeof globalThis.__golitFetch !== 'function') return;
+  globalThis.fetch ??= function (input, init) {
+    const url = typeof input === 'string'
+      ? input
+      : (input && typeof input.url === 'string')
+        ? input.url
+        : String(input);
+    const o = init && typeof init === 'object' ? init : {};
+    const headersObj = o.headers;
+    const headers = {};
+    if (headersObj && typeof headersObj === 'object') {
+      if (typeof headersObj.forEach === 'function') {
+        headersObj.forEach((v, k) => { headers[String(k)] = String(v); });
+      } else {
+        for (const k of Object.keys(headersObj)) {
+          headers[k] = String(headersObj[k]);
+        }
+      }
+    }
+    let bodyStr;
+    if (o.body != null) {
+      bodyStr = typeof o.body === 'string' ? o.body : String(o.body);
+    }
+    const initJson = JSON.stringify({
+      method: o.method,
+      headers,
+      body: bodyStr,
+    });
+    let raw;
+    try {
+      raw = globalThis.__golitFetch(url, initJson);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+    let d;
+    try {
+      d = JSON.parse(raw);
+    } catch (e) {
+      return Promise.reject(new Error('__golitFetch returned invalid JSON'));
+    }
+    if (d.error) {
+      return Promise.reject(new Error(d.error));
+    }
+    const textBody = d.body != null ? String(d.body) : '';
+    return Promise.resolve({
+      ok: !!d.ok,
+      status: d.status | 0,
+      statusText: d.statusText || '',
+      text() { return Promise.resolve(textBody); },
+      json() {
+        try {
+          return Promise.resolve(JSON.parse(textBody));
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      },
+      headers: {
+        get() { return null; },
+      },
+    });
+  };
+})();
+
 // Lit's isServer check -- set via esbuild's define option.
 // No assignment here to avoid esbuild warnings.

--- a/pkg/jsengine/domshim.js
+++ b/pkg/jsengine/domshim.js
@@ -1,48 +1,237 @@
 /**
- * Minimal DOM shim for running Lit components in QuickJS.
- * Provides just enough of the DOM API for Lit to:
- * 1. Register custom elements
- * 2. Instantiate components
- * 3. Set attributes
- * 4. Call render()
+ * DOM shim for running Lit components in QuickJS.
+ * Event/EventTarget modeled on @lit-labs/ssr-dom-shim/lib/events.js
+ * for full compatibility with @lit/context, controllers, and Lit lifecycle.
  *
- * Based on @lit-labs/ssr-dom-shim but stripped to essentials.
+ * Based on @lit-labs/ssr-dom-shim but adapted for QuickJS.
  */
 
-// --- EventTarget ---
+// --- Event phases ---
+const _NONE = 0;
+const _CAPTURING_PHASE = 1;
+const _AT_TARGET = 2;
+const _BUBBLING_PHASE = 3;
+
+const _isCaptureOption = (options) =>
+  typeof options === 'boolean' ? options : !!(options?.capture);
+
+// --- Event ---
 globalThis.Event = globalThis.Event || class Event {
   constructor(type, options) {
-    this.type = type;
-    this.bubbles = options?.bubbles || false;
-    this.composed = options?.composed || false;
-    this.cancelable = options?.cancelable || false;
+    if (arguments.length === 0) throw new Error('The type argument must be specified');
+    const opts = (typeof options === 'object' && options) ? options : {};
+    this._type = String(type);
+    this._bubbles = !!opts.bubbles;
+    this._composed = !!opts.composed;
+    this._cancelable = !!opts.cancelable;
+    this._defaultPrevented = false;
+    this._propagationStopped = false;
+    this._immediatePropagationStopped = false;
+    this._target = null;
+    this._currentTarget = null;
+    this._eventPhase = _NONE;
+    this._timestamp = Date.now();
+    this._isBeingDispatched = false;
+
+    this.NONE = _NONE;
+    this.CAPTURING_PHASE = _CAPTURING_PHASE;
+    this.AT_TARGET = _AT_TARGET;
+    this.BUBBLING_PHASE = _BUBBLING_PHASE;
+  }
+
+  get type() { return this._type; }
+  get bubbles() { return this._bubbles; }
+  get composed() { return this._composed; }
+  get cancelable() { return this._cancelable; }
+  get defaultPrevented() { return this._cancelable && this._defaultPrevented; }
+  get timeStamp() { return this._timestamp; }
+  get target() { return this._target; }
+  get currentTarget() { return this._currentTarget; }
+  get srcElement() { return this._target; }
+  get isTrusted() { return false; }
+  get returnValue() { return !this._cancelable || !this._defaultPrevented; }
+
+  get eventPhase() {
+    return this._isBeingDispatched ? this._eventPhase : _NONE;
+  }
+
+  get cancelBubble() { return this._propagationStopped; }
+  set cancelBubble(value) { if (value) this._propagationStopped = true; }
+
+  composedPath() {
+    return this._isBeingDispatched ? [this._target] : [];
+  }
+
+  stopPropagation() {
+    this._propagationStopped = true;
+  }
+
+  stopImmediatePropagation() {
+    this._propagationStopped = true;
+    this._immediatePropagationStopped = true;
+  }
+
+  preventDefault() {
+    this._defaultPrevented = true;
   }
 };
+globalThis.Event.NONE = _NONE;
+globalThis.Event.CAPTURING_PHASE = _CAPTURING_PHASE;
+globalThis.Event.AT_TARGET = _AT_TARGET;
+globalThis.Event.BUBBLING_PHASE = _BUBBLING_PHASE;
 
+// --- CustomEvent ---
 globalThis.CustomEvent = globalThis.CustomEvent || class CustomEvent extends Event {
   constructor(type, options) {
     super(type, options);
-    this.detail = options?.detail || null;
+    this._detail = (typeof options === 'object' && options) ? (options.detail ?? null) : null;
   }
+  get detail() { return this._detail; }
 };
 
+// --- EventTarget ---
 class EventTarget {
   constructor() {
-    this.__listeners = {};
+    this.__eventListeners = new Map();
+    this.__captureEventListeners = new Map();
   }
-  addEventListener(type, listener) {
-    (this.__listeners[type] = this.__listeners[type] || []).push(listener);
+
+  addEventListener(type, callback, options) {
+    if (callback == null) return;
+    const listenerMap = _isCaptureOption(options)
+      ? this.__captureEventListeners
+      : this.__eventListeners;
+    let listeners = listenerMap.get(type);
+    if (listeners === undefined) {
+      listeners = new Map();
+      listenerMap.set(type, listeners);
+    } else if (listeners.has(callback)) {
+      return;
+    }
+    const normalizedOpts = (typeof options === 'object' && options) ? options : {};
+    normalizedOpts.signal?.addEventListener?.('abort', () =>
+      this.removeEventListener(type, callback, options));
+    listeners.set(callback, normalizedOpts);
   }
-  removeEventListener(type, listener) {
-    const listeners = this.__listeners[type];
-    if (listeners) {
-      this.__listeners[type] = listeners.filter(l => l !== listener);
+
+  removeEventListener(type, callback, options) {
+    if (callback == null) return;
+    const listenerMap = _isCaptureOption(options)
+      ? this.__captureEventListeners
+      : this.__eventListeners;
+    const listeners = listenerMap.get(type);
+    if (listeners !== undefined) {
+      listeners.delete(callback);
+      if (!listeners.size) listenerMap.delete(type);
     }
   }
+
   dispatchEvent(event) {
-    const listeners = this.__listeners[event.type] || [];
-    for (const l of listeners) l.call(this, event);
-    return true;
+    const composedPath = [this];
+    let parent = this.__eventTargetParent;
+    if (event.composed) {
+      while (parent) {
+        composedPath.push(parent);
+        parent = parent.__eventTargetParent;
+      }
+    } else {
+      while (parent && parent !== this.__host) {
+        composedPath.push(parent);
+        parent = parent.__eventTargetParent;
+      }
+    }
+
+    let stopProp = false;
+    let stopImmediate = false;
+    let eventPhase = _NONE;
+    let target = null;
+    let tmpTarget = null;
+    let currentTarget = null;
+
+    const origStop = event.stopPropagation.bind(event);
+    const origImmediate = event.stopImmediatePropagation.bind(event);
+
+    Object.defineProperties(event, {
+      target: { get() { return target ?? tmpTarget; }, configurable: true, enumerable: true },
+      srcElement: { get() { return target ?? tmpTarget; }, configurable: true, enumerable: true },
+      currentTarget: { get() { return currentTarget; }, configurable: true, enumerable: true },
+      eventPhase: { get() { return eventPhase; }, configurable: true, enumerable: true },
+      composedPath: { value: () => composedPath, configurable: true, enumerable: true },
+      stopPropagation: {
+        value: () => { stopProp = true; origStop(); },
+        configurable: true, enumerable: true,
+      },
+      stopImmediatePropagation: {
+        value: () => { stopImmediate = true; origImmediate(); },
+        configurable: true, enumerable: true,
+      },
+    });
+
+    event._isBeingDispatched = true;
+
+    const invoke = (listener, opts, listenersMap) => {
+      if (typeof listener === 'function') {
+        listener(event);
+      } else if (typeof listener?.handleEvent === 'function') {
+        listener.handleEvent(event);
+      }
+      if (opts.once) listenersMap.delete(listener);
+    };
+
+    const finish = () => {
+      currentTarget = null;
+      eventPhase = _NONE;
+      event._isBeingDispatched = false;
+      return !event.defaultPrevented;
+    };
+
+    // Retarget event.target across shadow boundaries.
+    target = (!this.__host || !event.composed) ? this : null;
+    const retarget = (eventTargets) => {
+      tmpTarget = this;
+      while (tmpTarget.__host && eventTargets.includes(tmpTarget.__host)) {
+        tmpTarget = tmpTarget.__host;
+      }
+    };
+
+    // Capture phase (root -> target)
+    const capturePath = composedPath.slice().reverse();
+    for (const et of capturePath) {
+      if (!target && (!tmpTarget || tmpTarget === et.__host)) {
+        retarget(capturePath.slice(capturePath.indexOf(et)));
+      }
+      currentTarget = et;
+      eventPhase = (et === (target ?? tmpTarget)) ? _AT_TARGET : _CAPTURING_PHASE;
+      const listeners = et.__captureEventListeners?.get(event.type);
+      if (listeners) {
+        for (const [listener, opts] of listeners) {
+          invoke(listener, opts, listeners);
+          if (stopImmediate) return finish();
+        }
+      }
+      if (stopProp) return finish();
+    }
+
+    // Bubble phase (target -> root), or just [this] if non-bubbling.
+    const bubblePath = event.bubbles ? composedPath : [this];
+    tmpTarget = null;
+    for (const et of bubblePath) {
+      if (!target && (!tmpTarget || et === tmpTarget.__host)) {
+        retarget(bubblePath.slice(0, bubblePath.indexOf(et) + 1));
+      }
+      currentTarget = et;
+      eventPhase = (et === (target ?? tmpTarget)) ? _AT_TARGET : _BUBBLING_PHASE;
+      const listeners = et.__eventListeners?.get(event.type);
+      if (listeners) {
+        for (const [listener, opts] of listeners) {
+          invoke(listener, opts, listeners);
+          if (stopImmediate) return finish();
+        }
+      }
+      if (stopProp) return finish();
+    }
+
+    return finish();
   }
 }
 
@@ -138,6 +327,7 @@ class CustomElementRegistry {
   }
 
   define(name, ctor) {
+    if (this.__definitions.has(name)) return;
     ctor.__localName = name;
     this.__definitions.set(name, {
       ctor,
@@ -166,11 +356,11 @@ class CustomElementRegistry {
 
 // --- Globals ---
 // Use ??= so that loading multiple bundles into the same QJS engine
-// does not replace the registry (and wipe previously registered elements).
-globalThis.EventTarget = EventTarget;
-globalThis.Element = Element;
-globalThis.HTMLElement = HTMLElement;
-globalThis.CustomElementRegistry = CustomElementRegistry;
+// does not replace classes or the registry (and wipe previously registered elements).
+globalThis.EventTarget ??= EventTarget;
+globalThis.Element ??= Element;
+globalThis.HTMLElement ??= HTMLElement;
+globalThis.CustomElementRegistry ??= CustomElementRegistry;
 globalThis.customElements ??= new CustomElementRegistry();
 globalThis.document = globalThis.document || {
   nodeType: 9,
@@ -248,7 +438,7 @@ if (typeof globalThis.setTimeout === 'undefined') {
   globalThis.clearInterval = () => {};
 }
 globalThis.ErrorEvent = globalThis.ErrorEvent || class ErrorEvent extends Event {
-  constructor(type, init) { super(type); this.message = init?.message || ''; this.error = init?.error || null; }
+  constructor(type, init) { super(type, init); this.message = init?.message || ''; this.error = init?.error || null; }
 };
 globalThis.MutationObserver = globalThis.MutationObserver || class MutationObserver {
   constructor() {}
@@ -289,11 +479,12 @@ try {
 
 // Lit context root for SSR -- @lit/context checks globalThis.litServerRoot
 // when running in server mode and attaches event listeners to it.
-globalThis.litServerRoot = globalThis.litServerRoot || {
-  addEventListener: () => {},
-  removeEventListener: () => {},
-  dispatchEvent: () => true,
-};
+// Must be a real EventTarget so ContextProvider/ContextRoot can dispatch on it.
+globalThis.litServerRoot = globalThis.litServerRoot || (() => {
+  const root = new HTMLElement();
+  Object.defineProperty(root, 'localName', { get() { return 'lit-server-root'; } });
+  return root;
+})();
 
 // Dynamic import() shim for preloaded modules.
 // When golit pre-loads a module (e.g. prism-esm) into QJS as a script,

--- a/pkg/jsengine/domshim_test.go
+++ b/pkg/jsengine/domshim_test.go
@@ -1,6 +1,7 @@
 package jsengine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/fastschema/qjs"
@@ -92,6 +93,34 @@ func TestDOMShim_MultipleLoadsPreserveRegistry(t *testing.T) {
 	}
 	if result.String() != "true" {
 		t.Error("first-el should still be registered after loading domshim a second time")
+	}
+}
+
+func TestDOMShim_BareLocationBinding(t *testing.T) {
+	rt, err := qjs.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	ctx := rt.Context()
+	_, err = ctx.Eval("pre.js", qjs.Code(`globalThis.__golitLocationHref='http://localhost/';`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ctx.Eval("domshim.js", qjs.Code(domShimJS))
+	if err != nil {
+		t.Fatalf("loading DOM shim: %v", err)
+	}
+
+	result, err := ctx.Eval("test.js", qjs.Code(
+		`JSON.stringify({ gt: typeof globalThis.location, bare: typeof location })`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(result.String())
+	if strings.Contains(result.String(), `"bare":"undefined"`) {
+		t.Fatalf("bare location should resolve on global: %s", result.String())
 	}
 }
 

--- a/pkg/jsengine/domshim_test.go
+++ b/pkg/jsengine/domshim_test.go
@@ -1,11 +1,39 @@
 package jsengine
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/fastschema/qjs"
 )
+
+func loadShim(t *testing.T) (*qjs.Runtime, *qjs.Context) {
+	t.Helper()
+	rt, err := qjs.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := rt.Context()
+	if _, err := ctx.Eval("domshim.js", qjs.Code(domShimJS)); err != nil {
+		rt.Close()
+		t.Fatalf("loading DOM shim: %v", err)
+	}
+	return rt, ctx
+}
+
+func evalJSON(t *testing.T, ctx *qjs.Context, script string) map[string]interface{} {
+	t.Helper()
+	result, err := ctx.Eval("test.js", qjs.Code(script))
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(result.String()), &m); err != nil {
+		t.Fatalf("json parse %q: %v", result.String(), err)
+	}
+	return m
+}
 
 func TestDOMShim_CustomElements(t *testing.T) {
 	rt, err := qjs.New()
@@ -158,5 +186,312 @@ func TestDOMShim_ShadowRoot(t *testing.T) {
 	t.Logf("Result: %s", result.String())
 	if result.String() != `{"hasShadowRoot":true,"hostIsElement":true}` {
 		t.Errorf("unexpected result: %s", result.String())
+	}
+}
+
+// --- Event system tests ---
+
+func TestDOMShim_EventProperties(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const e = new Event('click', { bubbles: true, composed: true, cancelable: true });
+		const ce = new CustomEvent('my-event', { detail: { key: 42 }, bubbles: false });
+		JSON.stringify({
+			type: e.type,
+			bubbles: e.bubbles,
+			composed: e.composed,
+			cancelable: e.cancelable,
+			defaultPrevented: e.defaultPrevented,
+			isTrusted: e.isTrusted,
+			hasTimeStamp: typeof e.timeStamp === 'number',
+			hasComposedPath: typeof e.composedPath === 'function',
+			hasStopProp: typeof e.stopPropagation === 'function',
+			hasStopImmediate: typeof e.stopImmediatePropagation === 'function',
+			hasPreventDefault: typeof e.preventDefault === 'function',
+			ceType: ce.type,
+			ceBubbles: ce.bubbles,
+			ceDetail: ce.detail.key,
+			phaseNone: Event.NONE,
+			phaseCapture: Event.CAPTURING_PHASE,
+			phaseTarget: Event.AT_TARGET,
+			phaseBubble: Event.BUBBLING_PHASE,
+		});
+	`)
+
+	checks := map[string]interface{}{
+		"type": "click", "bubbles": true, "composed": true, "cancelable": true,
+		"defaultPrevented": false, "isTrusted": false,
+		"hasTimeStamp": true, "hasComposedPath": true, "hasStopProp": true,
+		"hasStopImmediate": true, "hasPreventDefault": true,
+		"ceType": "my-event", "ceBubbles": false, "ceDetail": float64(42),
+		"phaseNone": float64(0), "phaseCapture": float64(1),
+		"phaseTarget": float64(2), "phaseBubble": float64(3),
+	}
+	for k, want := range checks {
+		if m[k] != want {
+			t.Errorf("%s: got %v (%T), want %v (%T)", k, m[k], m[k], want, want)
+		}
+	}
+}
+
+func TestDOMShim_ComposedPathEmpty(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const e = new Event('test');
+		JSON.stringify({ path: e.composedPath(), len: e.composedPath().length });
+	`)
+
+	if length, ok := m["len"].(float64); !ok || length != 0 {
+		t.Errorf("composedPath before dispatch should be empty, got len=%v", m["len"])
+	}
+}
+
+func TestDOMShim_DispatchEventBasic(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const el = new HTMLElement();
+		let captured = {};
+		el.addEventListener('test', (e) => {
+			captured.type = e.type;
+			captured.hasTarget = e.target === el;
+			captured.hasCurrent = e.currentTarget === el;
+			captured.pathLen = e.composedPath().length;
+			captured.pathHasEl = e.composedPath()[0] === el;
+		});
+		const returned = el.dispatchEvent(new Event('test'));
+		captured.returned = returned;
+		JSON.stringify(captured);
+	`)
+
+	checks := map[string]interface{}{
+		"type": "test", "hasTarget": true, "hasCurrent": true,
+		"pathLen": float64(1), "pathHasEl": true, "returned": true,
+	}
+	for k, want := range checks {
+		if m[k] != want {
+			t.Errorf("%s: got %v, want %v", k, m[k], want)
+		}
+	}
+}
+
+func TestDOMShim_StopPropagation(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const child = new HTMLElement();
+		const parent = new HTMLElement();
+		child.__eventTargetParent = parent;
+
+		let calls = [];
+		child.addEventListener('test', (e) => {
+			calls.push('child');
+			e.stopPropagation();
+		});
+		parent.addEventListener('test', () => calls.push('parent'));
+
+		child.dispatchEvent(new Event('test', { bubbles: true, composed: true }));
+		JSON.stringify({ calls: calls });
+	`)
+
+	callsRaw, ok := m["calls"].([]interface{})
+	if !ok || len(callsRaw) != 1 || callsRaw[0] != "child" {
+		t.Errorf("stopPropagation should prevent parent: got %v", m["calls"])
+	}
+}
+
+func TestDOMShim_StopImmediatePropagation(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const el = new HTMLElement();
+		let calls = [];
+		el.addEventListener('test', (e) => {
+			calls.push('first');
+			e.stopImmediatePropagation();
+		});
+		el.addEventListener('test', () => calls.push('second'));
+
+		el.dispatchEvent(new Event('test'));
+		JSON.stringify({ calls: calls });
+	`)
+
+	callsRaw, ok := m["calls"].([]interface{})
+	if !ok || len(callsRaw) != 1 || callsRaw[0] != "first" {
+		t.Errorf("stopImmediatePropagation should prevent second listener: got %v", m["calls"])
+	}
+}
+
+func TestDOMShim_PreventDefault(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const el = new HTMLElement();
+		el.addEventListener('test', (e) => e.preventDefault());
+		const returned = el.dispatchEvent(new Event('test', { cancelable: true }));
+		JSON.stringify({ returned: returned });
+	`)
+
+	if m["returned"] != false {
+		t.Errorf("dispatchEvent should return false after preventDefault, got %v", m["returned"])
+	}
+}
+
+func TestDOMShim_CaptureVsBubbleOrder(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const el = new HTMLElement();
+		let order = [];
+		el.addEventListener('test', () => order.push('bubble'));
+		el.addEventListener('test', () => order.push('capture'), true);
+
+		el.dispatchEvent(new Event('test'));
+		JSON.stringify({ order: order });
+	`)
+
+	orderRaw, ok := m["order"].([]interface{})
+	if !ok || len(orderRaw) != 2 {
+		t.Fatalf("expected 2 calls, got %v", m["order"])
+	}
+	if orderRaw[0] != "capture" || orderRaw[1] != "bubble" {
+		t.Errorf("capture should fire before bubble: got %v", orderRaw)
+	}
+}
+
+func TestDOMShim_OnceListener(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const el = new HTMLElement();
+		let count = 0;
+		el.addEventListener('test', () => count++, { once: true });
+		el.dispatchEvent(new Event('test'));
+		el.dispatchEvent(new Event('test'));
+		JSON.stringify({ count: count });
+	`)
+
+	if m["count"] != float64(1) {
+		t.Errorf("once listener should fire only once, got count=%v", m["count"])
+	}
+}
+
+func TestDOMShim_ComposedPathParentChain(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const child = new HTMLElement();
+		const parent = new HTMLElement();
+		const root = new HTMLElement();
+		child.__eventTargetParent = parent;
+		parent.__eventTargetParent = root;
+
+		let pathLen = 0;
+		child.addEventListener('test', (e) => { pathLen = e.composedPath().length; });
+
+		child.dispatchEvent(new Event('test', { composed: true }));
+		JSON.stringify({ pathLen: pathLen });
+	`)
+
+	if m["pathLen"] != float64(3) {
+		t.Errorf("composed path should have 3 elements (child->parent->root), got %v", m["pathLen"])
+	}
+}
+
+func TestDOMShim_ContextRequestPattern(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		const provider = new HTMLElement();
+		let result = { composedPathCalled: false, noError: true, targetMatch: false };
+
+		provider.addEventListener('context-request', (e) => {
+			try {
+				const path = e.composedPath();
+				result.composedPathCalled = true;
+				const target = e.contextTarget ?? path[0];
+				result.targetMatch = target === provider;
+				e.stopPropagation();
+			} catch (err) {
+				result.noError = false;
+				result.error = err.message;
+			}
+		});
+
+		provider.dispatchEvent(new Event('context-request', { bubbles: true, composed: true }));
+		JSON.stringify(result);
+	`)
+
+	if m["composedPathCalled"] != true {
+		t.Errorf("composedPath should have been called")
+	}
+	if m["noError"] != true {
+		t.Errorf("should not throw, got error: %v", m["error"])
+	}
+	if m["targetMatch"] != true {
+		t.Errorf("target from composedPath should match provider")
+	}
+}
+
+func TestDOMShim_LitServerRoot(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		let called = false;
+		globalThis.litServerRoot.addEventListener('context-provider', () => { called = true; });
+		globalThis.litServerRoot.dispatchEvent(new Event('context-provider', { bubbles: true, composed: true }));
+		JSON.stringify({
+			isEventTarget: typeof globalThis.litServerRoot.addEventListener === 'function',
+			localName: globalThis.litServerRoot.localName,
+			called: called,
+		});
+	`)
+
+	if m["isEventTarget"] != true {
+		t.Errorf("litServerRoot should be a proper EventTarget")
+	}
+	if m["localName"] != "lit-server-root" {
+		t.Errorf("litServerRoot.localName should be 'lit-server-root', got %v", m["localName"])
+	}
+	if m["called"] != true {
+		t.Errorf("litServerRoot should dispatch events to registered listeners")
+	}
+}
+
+func TestDOMShim_DuplicateDefineIgnored(t *testing.T) {
+	rt, ctx := loadShim(t)
+	defer rt.Close()
+
+	m := evalJSON(t, ctx, `
+		class FirstEl extends HTMLElement { static get tag() { return 'first'; } }
+		class SecondEl extends HTMLElement { static get tag() { return 'second'; } }
+		customElements.define('dup-el', FirstEl);
+		customElements.define('dup-el', SecondEl);
+		const Ctor = customElements.get('dup-el');
+		const el = new Ctor();
+		JSON.stringify({
+			kept: Ctor.tag,
+			isFirst: Ctor === FirstEl,
+		});
+	`)
+
+	if m["kept"] != "first" {
+		t.Errorf("duplicate define should keep first class, got tag=%v", m["kept"])
+	}
+	if m["isFirst"] != true {
+		t.Errorf("duplicate define should not overwrite: isFirst=%v", m["isFirst"])
 	}
 }

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -59,6 +59,10 @@ func NewEngine() (*Engine, error) {
 // global scope once, so they don't need to be re-sent with every
 // RenderElement call.
 func (e *Engine) initHelpers() error {
+	if err := e.injectSSRStringGlobals(); err != nil {
+		return fmt.Errorf("inject SSR globals: %w", err)
+	}
+	e.installFetchBridge()
 	if _, err := e.ctx.Eval("helpers.js", qjs.Code(helpersJS)); err != nil {
 		return err
 	}

--- a/pkg/jsengine/fetchbridge.go
+++ b/pkg/jsengine/fetchbridge.go
@@ -1,0 +1,229 @@
+package jsengine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fastschema/qjs"
+)
+
+// SSR fetch defaults (override with GOLIT_FETCH_TIMEOUT_SEC, GOLIT_FETCH_MAX_BODY_BYTES).
+const (
+	defaultFetchTimeout  = 10 * time.Second
+	defaultFetchMaxBody  = 16 << 20 // 16 MiB
+	minFetchTimeout      = 1 * time.Second
+	maxFetchTimeout      = 5 * time.Minute
+	maxFetchMaxBody      = 64 << 20
+	envFetchAllowlist    = "GOLIT_FETCH_ALLOWLIST"
+	envFetchTimeoutSec   = "GOLIT_FETCH_TIMEOUT_SEC"
+	envFetchMaxBodyBytes = "GOLIT_FETCH_MAX_BODY_BYTES"
+	envSSRLocation       = "GOLIT_SSR_LOCATION"
+)
+
+type fetchInitJSON struct {
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers"`
+	Body    string            `json:"body"`
+}
+
+type fetchResultJSON struct {
+	OK         bool   `json:"ok"`
+	Status     int    `json:"status"`
+	StatusText string `json:"statusText"`
+	Body       string `json:"body"`
+	Error      string `json:"error,omitempty"`
+}
+
+// fetchHostAllowlist returns lowercase hostnames from GOLIT_FETCH_ALLOWLIST (comma-separated).
+// nil means no allowlist (only http/https are still required).
+func fetchHostAllowlist() map[string]bool {
+	raw := strings.TrimSpace(os.Getenv(envFetchAllowlist))
+	if raw == "" {
+		return nil
+	}
+	m := make(map[string]bool)
+	for _, h := range strings.Split(raw, ",") {
+		h = strings.TrimSpace(strings.ToLower(h))
+		if h != "" {
+			m[h] = true
+		}
+	}
+	return m
+}
+
+func fetchTimeout() time.Duration {
+	s := strings.TrimSpace(os.Getenv(envFetchTimeoutSec))
+	if s == "" {
+		return defaultFetchTimeout
+	}
+	sec, err := strconv.Atoi(s)
+	if err != nil || sec <= 0 {
+		return defaultFetchTimeout
+	}
+	d := time.Duration(sec) * time.Second
+	if d < minFetchTimeout {
+		return minFetchTimeout
+	}
+	if d > maxFetchTimeout {
+		return maxFetchTimeout
+	}
+	return d
+}
+
+func fetchMaxBody() int64 {
+	s := strings.TrimSpace(os.Getenv(envFetchMaxBodyBytes))
+	if s == "" {
+		return defaultFetchMaxBody
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n <= 0 {
+		return defaultFetchMaxBody
+	}
+	if n > maxFetchMaxBody {
+		return maxFetchMaxBody
+	}
+	return n
+}
+
+func ssrLocationHref() string {
+	h := strings.TrimSpace(os.Getenv(envSSRLocation))
+	if h == "" {
+		return "http://localhost/"
+	}
+	return h
+}
+
+func (e *Engine) injectSSRStringGlobals() error {
+	href, err := json.Marshal(ssrLocationHref())
+	if err != nil {
+		return err
+	}
+	_, err = e.ctx.Eval("golit-ssr-location.js", qjs.Code("globalThis.__golitLocationHref="+string(href)))
+	return err
+}
+
+// installFetchBridge registers globalThis.__golitFetch(url, initJson) for domshim fetch().
+func (e *Engine) installFetchBridge() {
+	allow := fetchHostAllowlist()
+	timeout := fetchTimeout()
+	maxBody := fetchMaxBody()
+
+	e.ctx.SetFunc("__golitFetch", func(th *qjs.This) (*qjs.Value, error) {
+		c := th.Context()
+		args := th.Args()
+		if len(args) < 1 {
+			return fetchErrorString(c, "__golitFetch: missing url")
+		}
+		if args[0].IsUndefined() || args[0].IsNull() {
+			return fetchErrorString(c, "__golitFetch: url is null or undefined")
+		}
+		urlStr := args[0].String()
+		initJSON := "{}"
+		if len(args) >= 2 && !args[1].IsUndefined() && !args[1].IsNull() {
+			initJSON = args[1].String()
+		}
+
+		out, err := runGolitFetch(urlStr, initJSON, allow, timeout, maxBody)
+		if err != nil {
+			return fetchErrorString(c, err.Error())
+		}
+		// Return a JSON string so JS can JSON.parse (matches domshim fetch wrapper).
+		return c.NewString(string(out)), nil
+	})
+}
+
+func fetchErrorString(c *qjs.Context, msg string) (*qjs.Value, error) {
+	b, err := json.Marshal(fetchResultJSON{Error: msg})
+	if err != nil {
+		return nil, err
+	}
+	return c.NewString(string(b)), nil
+}
+
+func runGolitFetch(urlStr, initJSON string, allow map[string]bool, timeout time.Duration, maxBody int64) ([]byte, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("only http and https URLs are allowed")
+	}
+	host := strings.ToLower(u.Hostname())
+	if allow != nil && !allow[host] {
+		return nil, fmt.Errorf("fetch host %q not in %s", host, envFetchAllowlist)
+	}
+
+	var init fetchInitJSON
+	if strings.TrimSpace(initJSON) != "" && initJSON != "{}" {
+		if err := json.Unmarshal([]byte(initJSON), &init); err != nil {
+			return nil, fmt.Errorf("invalid fetch init JSON: %w", err)
+		}
+	}
+	method := strings.ToUpper(strings.TrimSpace(init.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	if method != http.MethodGet && method != http.MethodHead && method != http.MethodPost &&
+		method != http.MethodPut && method != http.MethodPatch && method != http.MethodDelete {
+		return nil, fmt.Errorf("unsupported fetch method %q", method)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if init.Body != "" && (method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch) {
+		bodyReader = strings.NewReader(init.Body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range init.Headers {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	if init.Body != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "text/plain;charset=UTF-8")
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxBody+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBody {
+		return nil, fmt.Errorf("response body exceeds max size (%d bytes)", maxBody)
+	}
+
+	statusText := http.StatusText(resp.StatusCode)
+	if statusText == "" {
+		statusText = resp.Status
+	}
+	res := fetchResultJSON{
+		OK:         resp.StatusCode >= 200 && resp.StatusCode < 300,
+		Status:     resp.StatusCode,
+		StatusText: statusText,
+		Body:       string(data),
+	}
+	return json.Marshal(res)
+}

--- a/pkg/jsengine/fetchbridge_test.go
+++ b/pkg/jsengine/fetchbridge_test.go
@@ -1,0 +1,129 @@
+package jsengine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/fastschema/qjs"
+)
+
+func TestRunGolitFetch_GET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello"))
+	}))
+	t.Cleanup(srv.Close)
+
+	raw, err := runGolitFetch(srv.URL, "{}", nil, defaultFetchTimeout, defaultFetchMaxBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"ok":true`) || !strings.Contains(string(raw), "hello") {
+		t.Fatalf("unexpected JSON: %s", raw)
+	}
+}
+
+func TestRunGolitFetch_AllowlistDeny(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("x"))
+	}))
+	t.Cleanup(srv.Close)
+
+	pu, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := strings.ToLower(pu.Hostname())
+
+	allow := map[string]bool{"some-other-host.invalid": true}
+	_, err = runGolitFetch(srv.URL, "{}", allow, defaultFetchTimeout, defaultFetchMaxBody)
+	if err == nil || !strings.Contains(err.Error(), "not in") {
+		t.Fatalf("expected allowlist error, got %v", err)
+	}
+
+	allow[host] = true
+	raw, err := runGolitFetch(srv.URL, "{}", allow, defaultFetchTimeout, defaultFetchMaxBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"ok":true`) {
+		t.Fatalf("expected ok: %s", raw)
+	}
+}
+
+func TestRunGolitFetch_SchemeReject(t *testing.T) {
+	_, err := runGolitFetch("file:///etc/passwd", "{}", nil, defaultFetchTimeout, defaultFetchMaxBody)
+	if err == nil || !strings.Contains(err.Error(), "only http") {
+		t.Fatalf("expected scheme error, got %v", err)
+	}
+}
+
+func TestDOMShim_FetchViaBridge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"a":1}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(envFetchAllowlist, "")
+	rt, err := qjs.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	ctx := rt.Context()
+	eng := &Engine{runtime: rt, ctx: ctx, loaded: make(map[string]bool)}
+	if err := eng.injectSSRStringGlobals(); err != nil {
+		t.Fatal(err)
+	}
+	eng.installFetchBridge()
+
+	_, err = ctx.Eval("domshim.js", qjs.Code(domShimJS))
+	if err != nil {
+		t.Fatalf("domshim: %v", err)
+	}
+
+	js := `JSON.stringify({
+		hasFetch: typeof fetch === 'function',
+		loc: typeof location !== 'undefined' && location.href.length > 0,
+		mm: typeof matchMedia
+	});`
+	res, err := ctx.Eval("chk.js", qjs.Code(js))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := res.String()
+	if !strings.Contains(s, `"hasFetch":true`) {
+		t.Fatalf("expected fetch: %s", s)
+	}
+	if !strings.Contains(s, `"loc":true`) {
+		t.Fatalf("expected location: %s", s)
+	}
+	if !strings.Contains(s, `"mm":"undefined"`) {
+		t.Fatalf("matchMedia should be undefined, got %s", s)
+	}
+
+	// fetch() returns a Promise; verify __golitFetch JSON and fetch is a thenable factory.
+	fetchJS := `(function() {
+		const u = ` + strconv.Quote(srv.URL) + `;
+		const raw = globalThis.__golitFetch(u, '{}');
+		const d = JSON.parse(raw);
+		if (!d.ok || d.status !== 200 || d.body !== '{"a":1}') return 'bad-direct';
+		if (typeof fetch !== 'function') return 'bad-fetch-fn';
+		const p = fetch(u);
+		if (!p || typeof p.then !== 'function') return 'bad-promise';
+		return 'ok';
+	})();`
+	res2, err := ctx.Eval("fetch-test.js", qjs.Code(fetchJS))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.String() != "ok" {
+		t.Fatalf("fetch wrapper: %s", res2.String())
+	}
+}


### PR DESCRIPTION
## Summary

Aligns QuickJS SSR with Lit `getWindow()`-style globals: stable `location`, `URL` / `URLSearchParams` when missing, and real `fetch` via a Go bridge (similar in spirit to Lit + node-fetch). `matchMedia` remains undefined.

## Changes

- **Go fetch bridge** (`__golitFetch`): `http`/`https` only; optional `GOLIT_FETCH_ALLOWLIST`; `GOLIT_FETCH_TIMEOUT_SEC` and `GOLIT_FETCH_MAX_BODY_BYTES` with sane defaults; `GOLIT_SSR_LOCATION` for `__golitLocationHref`.
- **domshim**: `location`, URL polyfills, `fetch` wrapper; tests for fetch bridge and bare `location` binding.
- **README**: documents SSR fetch behavior and env vars.

## Testing

`go test ./...`

Closes #5 

Made with [Cursor](https://cursor.com)