### PR TITLE
fix(bundler): non-fatal discovery errors and dynamic import resolution (#10, #11)

### DIFF
--- a/pkg/jsengine/bundler.go
+++ b/pkg/jsengine/bundler.go
@@ -205,7 +205,7 @@ func bundleComponent(componentPath string, opt BundleOptions) (string, error) {
 		return "", err
 	}
 
-	code, hasTopLevelAwait := stripESMExports(esm)
+	code, hasTopLevelAwait, _ := stripESMExports(esm)
 	if hasTopLevelAwait {
 		code = "(async () => {\n" + code + "\n})();\n"
 	}
@@ -267,11 +267,12 @@ func bundleComponentRaw(componentPath string, opt BundleOptions) (string, error)
 }
 
 // stripESMExports removes export keywords from bundled ESM output so it
-// can be evaluated in QJS script mode. Since esbuild has already bundled
-// all dependencies, there are no import statements to handle.
-// Also detects top-level await (await at column 0, not inside functions).
-func stripESMExports(code string) (string, bool) {
+// can be evaluated in QJS script mode. Returns the stripped code, whether
+// top-level await was found, and whether a default export was found.
+// Default exports are assigned to __golit_default_export for later capture.
+func stripESMExports(code string) (string, bool, bool) {
 	hasTopLevelAwait := false
+	hasDefaultExport := false
 	inExportBlock := false
 	var b strings.Builder
 	b.Grow(len(code))
@@ -312,7 +313,8 @@ func stripESMExports(code string) (string, bool) {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "export default ") {
-			b.WriteString(strings.Replace(line, "export default ", "", 1))
+			b.WriteString(strings.Replace(line, "export default ", "var __golit_default_export = ", 1))
+			hasDefaultExport = true
 			continue
 		}
 		if strings.HasPrefix(trimmed, "export var ") ||
@@ -334,7 +336,7 @@ func stripESMExports(code string) (string, bool) {
 		b.WriteString(line)
 	}
 
-	return b.String(), hasTopLevelAwait
+	return b.String(), hasTopLevelAwait, hasDefaultExport
 }
 
 
@@ -475,7 +477,7 @@ func BundleSource(source string, opts ...BundleOptions) (string, error) {
 	}
 
 	code := string(result.OutputFiles[0].Contents)
-	code, hasTopLevelAwait := stripESMExports(code)
+	code, hasTopLevelAwait, _ := stripESMExports(code)
 	if hasTopLevelAwait {
 		code = "(async () => {\n" + code + "\n})();\n"
 	}
@@ -495,18 +497,24 @@ func BundlePreload(modulePath string, name string) (string, error) {
 
 	exportNames := extractESMExportNames(esm)
 
-	code, hasTopLevelAwait := stripESMExports(esm)
+	code, hasTopLevelAwait, hasDefaultExport := stripESMExports(esm)
 	if hasTopLevelAwait {
 		code = "(async () => {\n" + code + "\n})();\n"
 	}
 
 	var capture strings.Builder
 	capture.WriteString(fmt.Sprintf("\nglobalThis.__preloadedModules[%q] = {", name))
-	for i, n := range exportNames {
-		if i > 0 {
+	first := true
+	if hasDefaultExport {
+		capture.WriteString("default: (typeof __golit_default_export !== 'undefined' ? __golit_default_export : undefined)")
+		first = false
+	}
+	for _, n := range exportNames {
+		if !first {
 			capture.WriteString(", ")
 		}
 		capture.WriteString(fmt.Sprintf("%s: (typeof %s !== 'undefined' ? %s : undefined)", n, n, n))
+		first = false
 	}
 	capture.WriteString("};\n")
 

--- a/pkg/jsengine/bundler.go
+++ b/pkg/jsengine/bundler.go
@@ -1006,6 +1006,43 @@ func buildRuntimeEntryFromModules(modules map[string]string) string {
 	return b.String()
 }
 
+// ExtractDynamicImportTargets scans thin module sources for dynamic import()
+// calls and returns non-local, non-runtime specifiers.
+// Matches patterns like: import("@rhds/tokens/css/default-theme.css.js")
+func ExtractDynamicImportTargets(modules map[string]string) []string {
+	return extractDynamicImportTargets(modules)
+}
+
+func extractDynamicImportTargets(modules map[string]string) []string {
+	seen := make(map[string]bool)
+	var targets []string
+
+	for _, source := range modules {
+		for _, line := range strings.Split(source, "\n") {
+			trimmed := strings.TrimSpace(line)
+			for _, quote := range []string{`"`, `'`} {
+				prefix := "import(" + quote
+				idx := strings.Index(trimmed, prefix)
+				if idx < 0 {
+					continue
+				}
+				rest := trimmed[idx+len(prefix):]
+				end := strings.Index(rest, quote+")")
+				if end < 0 {
+					continue
+				}
+				spec := rest[:end]
+				if !isLocalOrRuntime(spec) && !seen[spec] {
+					seen[spec] = true
+					targets = append(targets, spec)
+				}
+			}
+		}
+	}
+	sort.Strings(targets)
+	return targets
+}
+
 // ResolveModulePath resolves a bare module specifier to a file path by
 // looking up its entry point in node_modules/package.json.
 func ResolveModulePath(specifier string, fromDir string) (string, error) {

--- a/pkg/jsengine/bundler.go
+++ b/pkg/jsengine/bundler.go
@@ -126,13 +126,14 @@ func DiscoverExternalPackages(componentPaths []string, nodeModulesDir string, op
 	})
 
 	if len(result.Errors) > 0 {
-		var msgs []string
 		for _, e := range result.Errors {
-			msgs = append(msgs, e.Text)
+			fmt.Fprintf(os.Stderr, "golit: warning: discovery: %s\n", e.Text)
 		}
-		return nil, fmt.Errorf("esbuild discovery errors: %s", strings.Join(msgs, "; "))
 	}
 
+	if result.Metafile == "" {
+		return nil, nil
+	}
 	return parseMetafilePackages(result.Metafile)
 }
 

--- a/pkg/jsengine/bundler.go
+++ b/pkg/jsengine/bundler.go
@@ -1018,25 +1018,33 @@ func extractDynamicImportTargets(modules map[string]string) []string {
 	var targets []string
 
 	for _, source := range modules {
-		for _, line := range strings.Split(source, "\n") {
-			trimmed := strings.TrimSpace(line)
-			for _, quote := range []string{`"`, `'`} {
-				prefix := "import(" + quote
-				idx := strings.Index(trimmed, prefix)
-				if idx < 0 {
-					continue
-				}
-				rest := trimmed[idx+len(prefix):]
-				end := strings.Index(rest, quote+")")
-				if end < 0 {
-					continue
-				}
-				spec := rest[:end]
-				if !isLocalOrRuntime(spec) && !seen[spec] {
-					seen[spec] = true
-					targets = append(targets, spec)
-				}
+		pos := 0
+		for pos < len(source) {
+			idx := strings.Index(source[pos:], "import(")
+			if idx < 0 {
+				break
 			}
+			start := pos + idx + len("import(")
+			if start >= len(source) {
+				break
+			}
+			quote := source[start]
+			if quote != '"' && quote != '\'' {
+				pos = start
+				continue
+			}
+			closeStr := string(quote) + ")"
+			end := strings.Index(source[start+1:], closeStr)
+			if end < 0 {
+				pos = start + 1
+				continue
+			}
+			spec := source[start+1 : start+1+end]
+			if !isLocalOrRuntime(spec) && !seen[spec] {
+				seen[spec] = true
+				targets = append(targets, spec)
+			}
+			pos = start + 1 + end + len(closeStr)
 		}
 	}
 	sort.Strings(targets)

--- a/pkg/jsengine/bundler_test.go
+++ b/pkg/jsengine/bundler_test.go
@@ -1,9 +1,118 @@
 package jsengine
 
 import (
+	"sort"
 	"strings"
 	"testing"
 )
+
+func TestExtractDynamicImportTargets(t *testing.T) {
+	cases := []struct {
+		name    string
+		modules map[string]string
+		want    []string
+	}{
+		{
+			name: "finds double-quoted dynamic import",
+			modules: map[string]string{
+				"comp.js": `const { default: { cssText } } = await import("@rhds/tokens/css/default-theme.css.js");`,
+			},
+			want: []string{"@rhds/tokens/css/default-theme.css.js"},
+		},
+		{
+			name: "finds single-quoted dynamic import",
+			modules: map[string]string{
+				"comp.js": `await import('@some/pkg/styles.css.js');`,
+			},
+			want: []string{"@some/pkg/styles.css.js"},
+		},
+		{
+			name: "ignores local imports",
+			modules: map[string]string{
+				"comp.js": `import("./local.js")`,
+			},
+			want: nil,
+		},
+		{
+			name: "ignores @golit/runtime",
+			modules: map[string]string{
+				"comp.js": `import("@golit/runtime")`,
+			},
+			want: nil,
+		},
+		{
+			name: "deduplicates across modules",
+			modules: map[string]string{
+				"a.js": `import("@rhds/tokens/css/default-theme.css.js");`,
+				"b.js": `import("@rhds/tokens/css/default-theme.css.js");`,
+			},
+			want: []string{"@rhds/tokens/css/default-theme.css.js"},
+		},
+		{
+			name: "finds multiple targets across lines",
+			modules: map[string]string{
+				"comp.js": "import(\"@rhds/tokens/css/default-theme.css.js\");\nimport(\"@rhds/icons/ui/check.js\");",
+			},
+			want: []string{"@rhds/icons/ui/check.js", "@rhds/tokens/css/default-theme.css.js"},
+		},
+		{
+			name: "finds multiple targets on same line",
+			modules: map[string]string{
+				"comp.js": `import("@rhds/tokens/css/default-theme.css.js"); import("@rhds/icons/ui/check.js");`,
+			},
+			want: []string{"@rhds/icons/ui/check.js", "@rhds/tokens/css/default-theme.css.js"},
+		},
+		{
+			name: "handles mixed quotes on same line",
+			modules: map[string]string{
+				"comp.js": `import("@rhds/tokens/css/default-theme.css.js"); import('@rhds/icons/ui/check.js');`,
+			},
+			want: []string{"@rhds/icons/ui/check.js", "@rhds/tokens/css/default-theme.css.js"},
+		},
+		{
+			name:    "empty modules",
+			modules: map[string]string{},
+			want:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractDynamicImportTargets(tc.modules)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d targets %v, want %d targets %v", len(got), got, len(tc.want), tc.want)
+			}
+			sort.Strings(got)
+			sort.Strings(tc.want)
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("target[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverExternalPackages_NonFatalErrors(t *testing.T) {
+	// DiscoverExternalPackages with no valid entry points should return nil, nil
+	// (not an error) since there's nothing to discover.
+	result, err := DiscoverExternalPackages(nil, "")
+	if err != nil {
+		t.Fatalf("expected nil error for empty input, got: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result for empty input, got: %v", result)
+	}
+
+	// With non-existent paths, should also return nil, nil (paths are filtered out)
+	result, err = DiscoverExternalPackages([]string{"/nonexistent/path.js"}, "/nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil error for non-existent paths, got: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result for non-existent paths, got: %v", result)
+	}
+}
 
 func TestBundleComponent_MyGreeting(t *testing.T) {
 	bundle, err := BundleComponent("../../testdata/sources/my-greeting.js")

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -31,10 +31,11 @@ type RenderResult struct {
 
 // Engine executes Lit components in QJS for SSR rendering.
 type Engine struct {
-	runtime        *qjs.Runtime
-	ctx            *qjs.Context
-	loaded         map[string]bool // track which bundles have been loaded
-	preloadModules []string        // module names available via __preloadedModules
+	runtime          *qjs.Runtime
+	ctx              *qjs.Context
+	loaded           map[string]bool // track which bundles have been loaded
+	preloadModules   []string        // module names available via __preloadedModules
+	runtimeExternals []string        // package prefixes bundled into @golit/runtime
 }
 
 // NewEngine creates a new QJS engine instance.
@@ -101,6 +102,13 @@ func (e *Engine) SetPreloadModules(modules []string) {
 	e.preloadModules = modules
 }
 
+// SetRuntimeExternals tells the engine which package prefixes are bundled
+// into the @golit/runtime module. Dynamic import() calls for these packages
+// will be rewritten to import("@golit/runtime").
+func (e *Engine) SetRuntimeExternals(externals []string) {
+	e.runtimeExternals = externals
+}
+
 // LoadBundle loads a pre-bundled component JS file into the engine as a script.
 // Can be called multiple times to load multiple components.
 // If preload modules are set, dynamic import() calls for those modules
@@ -145,10 +153,12 @@ type shimPattern struct {
 }
 
 // shimDynamicImports replaces dynamic import("module") expressions with
-// Promise.resolve(globalThis.__preloadedModules["module"]) for preloaded modules.
+// Promise.resolve(globalThis.__preloadedModules["module"]) for preloaded modules,
+// and rewrites import("pkg/...") to import("@golit/runtime") for packages
+// bundled into the shared runtime.
 // Handles both quote styles and subpath imports (e.g. import("mod/sub.js")).
 func (e *Engine) shimDynamicImports(code string) string {
-	if len(e.preloadModules) == 0 || !strings.Contains(code, "import(") {
+	if (len(e.preloadModules) == 0 && len(e.runtimeExternals) == 0) || !strings.Contains(code, "import(") {
 		return code
 	}
 
@@ -181,9 +191,6 @@ func (e *Engine) shimDynamicImports(code string) string {
 				code[matchStart:matchStart+len(p.prefix)] != p.prefix {
 				continue
 			}
-			// Boundary check: the char after the module name must be
-			// the closing quote (exact match) or '/' (subpath import).
-			// Without this, preloading "lit" would also match "lit-html".
 			nextChar := code[matchStart+len(p.prefix)]
 			if nextChar != p.close[0] && nextChar != '/' {
 				continue
@@ -203,6 +210,14 @@ func (e *Engine) shimDynamicImports(code string) string {
 			break
 		}
 
+		if !matched && len(e.runtimeExternals) > 0 {
+			if rewritten, newPos := e.shimRuntimeImport(code, matchStart); rewritten != "" {
+				b.WriteString(rewritten)
+				pos = newPos
+				matched = true
+			}
+		}
+
 		if !matched {
 			b.WriteString(importOpen)
 			pos = matchStart + len(importOpen)
@@ -210,6 +225,30 @@ func (e *Engine) shimDynamicImports(code string) string {
 	}
 
 	return b.String()
+}
+
+// shimRuntimeImport checks if a dynamic import() at the given position
+// matches a runtime external package and rewrites it to import("@golit/runtime").
+func (e *Engine) shimRuntimeImport(code string, matchStart int) (string, int) {
+	for _, quote := range []byte{'"', '\''} {
+		prefix := `import(` + string(quote)
+		if matchStart+len(prefix) > len(code) ||
+			code[matchStart:matchStart+len(prefix)] != prefix {
+			continue
+		}
+		closeStr := string(quote) + ")"
+		end := strings.Index(code[matchStart+len(prefix):], closeStr)
+		if end < 0 {
+			continue
+		}
+		specifier := code[matchStart+len(prefix) : matchStart+len(prefix)+end]
+		if matchesExternals(specifier, e.runtimeExternals) {
+			full := code[matchStart : matchStart+len(prefix)+end+len(closeStr)]
+			rewritten := `import(` + string(quote) + `@golit/runtime` + string(quote) + `)/*golit-runtime:` + full + `*/`
+			return rewritten, matchStart + len(full)
+		}
+	}
+	return "", 0
 }
 
 // LoadBundleForTag loads a component from the registry for a specific tag name.
@@ -232,6 +271,10 @@ func (e *Engine) LoadBundleForTag(tagName string, registry *Registry) (bool, err
 			return false, fmt.Errorf("loading shared runtime: %w", err)
 		}
 		e.loaded["@golit/runtime"] = true
+	}
+
+	if ext := registry.RuntimeExternals(); len(ext) > 0 && len(e.runtimeExternals) == 0 {
+		e.runtimeExternals = ext
 	}
 
 	if err := e.EvalModule(tagName+".js", source); err != nil {

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -210,6 +210,81 @@ func TestShimDynamicImports_NoModules(t *testing.T) {
 	}
 }
 
+func TestShimDynamicImports_RuntimeExternals(t *testing.T) {
+	e := &Engine{runtimeExternals: []string{
+		"@rhds/tokens", "@rhds/tokens/*",
+		"@rhds/icons", "@rhds/icons/*",
+	}}
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "exact match rewrites to runtime",
+			input: `import("@rhds/tokens")`,
+			want:  `import("@golit/runtime")/*golit-runtime:import("@rhds/tokens")*/`,
+		},
+		{
+			name:  "subpath rewrites to runtime",
+			input: `import("@rhds/tokens/css/default-theme.css.js")`,
+			want:  `import("@golit/runtime")/*golit-runtime:import("@rhds/tokens/css/default-theme.css.js")*/`,
+		},
+		{
+			name:  "single quotes work too",
+			input: `import('@rhds/icons/ui/check.js')`,
+			want:  `import('@golit/runtime')/*golit-runtime:import('@rhds/icons/ui/check.js')*/`,
+		},
+		{
+			name:  "non-external package unchanged",
+			input: `import("@other/pkg")`,
+			want:  `import("@other/pkg")`,
+		},
+		{
+			name:  "local import unchanged",
+			input: `import("./local.js")`,
+			want:  `import("./local.js")`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := e.shimDynamicImports(tc.input)
+			if got != tc.want {
+				t.Errorf("got:\n  %s\nwant:\n  %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShimDynamicImports_PreloadTakesPrecedence(t *testing.T) {
+	e := &Engine{
+		preloadModules:   []string{"prism-esm"},
+		runtimeExternals: []string{"prism-esm", "prism-esm/*", "@rhds/tokens", "@rhds/tokens/*"},
+	}
+
+	got := e.shimDynamicImports(`import("prism-esm/components/prism-css.js")`)
+	want := `Promise.resolve(globalThis.__preloadedModules["prism-esm"] || {})/*golit-shimmed:import("prism-esm/components/prism-css.js")*/`
+	if got != want {
+		t.Errorf("preload should take precedence over runtime externals\ngot:\n  %s\nwant:\n  %s", got, want)
+	}
+
+	got = e.shimDynamicImports(`import("@rhds/tokens/css/default-theme.css.js")`)
+	want = `import("@golit/runtime")/*golit-runtime:import("@rhds/tokens/css/default-theme.css.js")*/`
+	if got != want {
+		t.Errorf("non-preloaded externals should use runtime rewrite\ngot:\n  %s\nwant:\n  %s", got, want)
+	}
+}
+
+func TestShimDynamicImports_BothEmpty(t *testing.T) {
+	e := &Engine{}
+	input := `import("@rhds/tokens/css/default-theme.css.js")`
+	if got := e.shimDynamicImports(input); got != input {
+		t.Errorf("expected no change when both preload and externals are empty, got %q", got)
+	}
+}
+
 func TestEngine_UnregisteredElement(t *testing.T) {
 	engine, err := NewEngine()
 	if err != nil {

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -42,12 +42,20 @@ func NewEnginePool(size int) (*EnginePool, error) {
 func (p *EnginePool) PreloadAll(registry *Registry, preloadModules []string, preloadBundles ...string) error {
 	tags := registry.TagNames()
 
-	// Bundle dynamic import targets (e.g. CSS modules) as preloaded modules.
-	// These are specifiers found in thin module import() calls that need to
-	// be resolvable at runtime.
+	// Bundle dynamic import targets that aren't already in preloadModules.
+	// When called from transform.go, targets are pre-bundled and passed via
+	// preloadBundles/preloadModules. When called from serve.go, this is the
+	// only place they get bundled.
+	already := make(map[string]bool, len(preloadModules))
+	for _, m := range preloadModules {
+		already[m] = true
+	}
 	var dynamicBundles []string
 	allPreloadModules := append([]string(nil), preloadModules...)
 	for _, target := range registry.DynamicImportTargets() {
+		if already[target] {
+			continue
+		}
 		modPath, err := ResolveModulePath(target, ".")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "golit: warning: cannot resolve dynamic import target %s: %v\n", target, err)

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -35,18 +35,44 @@ func NewEnginePool(size int) (*EnginePool, error) {
 }
 
 // PreloadAll drains every engine from the pool, configures preload modules,
-// loads any raw preload bundles, loads the shared runtime (if present), then
-// loads all registry component bundles/modules.
+// loads any raw preload bundles, bundles dynamic import targets as preloads,
+// loads the shared runtime (if present), then loads all registry component
+// bundles/modules.
 // After this call the registry must be treated as read-only.
 func (p *EnginePool) PreloadAll(registry *Registry, preloadModules []string, preloadBundles ...string) error {
 	tags := registry.TagNames()
+
+	// Bundle dynamic import targets (e.g. CSS modules) as preloaded modules.
+	// These are specifiers found in thin module import() calls that need to
+	// be resolvable at runtime.
+	var dynamicBundles []string
+	allPreloadModules := append([]string(nil), preloadModules...)
+	for _, target := range registry.DynamicImportTargets() {
+		modPath, err := ResolveModulePath(target, ".")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "golit: warning: cannot resolve dynamic import target %s: %v\n", target, err)
+			continue
+		}
+		bundle, err := BundlePreload(modPath, target)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "golit: warning: cannot bundle dynamic import target %s: %v\n", target, err)
+			continue
+		}
+		dynamicBundles = append(dynamicBundles, bundle)
+		allPreloadModules = append(allPreloadModules, target)
+	}
+
 	drained := make([]*Engine, 0, p.size)
 
 	for i := 0; i < p.size; i++ {
 		e := <-p.engines
-		e.SetPreloadModules(preloadModules)
+		e.SetPreloadModules(allPreloadModules)
+		e.SetRuntimeExternals(registry.RuntimeExternals())
 		for _, pb := range preloadBundles {
 			_ = e.LoadBundle(pb)
+		}
+		for _, db := range dynamicBundles {
+			_ = e.LoadBundle(db)
 		}
 		// Load shared runtime once per engine before any components.
 		if rt := registry.SharedRuntime(); rt != "" && !e.loaded["@golit/runtime"] {

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -56,7 +56,11 @@ func (p *EnginePool) PreloadAll(registry *Registry, preloadModules []string, pre
 		if already[target] {
 			continue
 		}
-		modPath, err := ResolveModulePath(target, ".")
+		baseDir := registry.BaseDir()
+		if baseDir == "" {
+			baseDir = "."
+		}
+		modPath, err := ResolveModulePath(target, baseDir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "golit: warning: cannot resolve dynamic import target %s: %v\n", target, err)
 			continue

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -33,6 +33,18 @@ type Registry struct {
 	// sharedRuntime is the shared runtime module source (loaded once per engine)
 	sharedRuntime string
 
+	// runtimeExternals lists the package prefixes bundled into the shared
+	// runtime (e.g. "lit", "lit/*", "@rhds/tokens", "@rhds/tokens/*").
+	// Used by Engine.shimDynamicImports to rewrite dynamic import() calls
+	// for these packages to import("@golit/runtime").
+	runtimeExternals []string
+
+	// dynamicImportTargets lists specific module specifiers that appear in
+	// dynamic import() calls in thin modules (e.g. "@rhds/tokens/css/default-theme.css.js").
+	// These need to be bundled as standalone preloaded modules so the engine
+	// can resolve them at runtime.
+	dynamicImportTargets []string
+
 	// unregistered tracks custom element tags found but not in the registry
 	unregistered map[string]bool
 
@@ -53,12 +65,15 @@ func NewRegistry() *Registry {
 
 // LoadDir loads all .golit.module.js files from a directory.
 // If a _runtime.golit.module.js file is present, it is loaded as the shared runtime.
-// Tag names are discovered via a regex pre-pass.
+// Tag names are discovered via a regex pre-pass. Dynamic import() targets in
+// the thin modules are collected to populate runtime externals.
 func (r *Registry) LoadDir(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("reading modules directory %s: %w", dir, err)
 	}
+
+	moduleSources := make(map[string]string)
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -82,9 +97,17 @@ func (r *Registry) LoadDir(dir string) error {
 				return fmt.Errorf("reading module %s: %w", name, err)
 			}
 			source := string(data)
+			moduleSources[name] = source
 			if tagName, ok := discoverTagNameFast(source); ok {
 				r.RegisterModule(tagName, source)
 			}
+		}
+	}
+
+	if len(moduleSources) > 0 {
+		targets := extractDynamicImportTargets(moduleSources)
+		if len(targets) > 0 {
+			r.SetDynamicImportTargets(targets)
 		}
 	}
 
@@ -145,6 +168,35 @@ func (r *Registry) SharedRuntime() string {
 func (r *Registry) SetSharedRuntime(source string) {
 	r.mu.Lock()
 	r.sharedRuntime = source
+	r.mu.Unlock()
+}
+
+// RuntimeExternals returns the package prefixes bundled into the shared runtime.
+func (r *Registry) RuntimeExternals() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.runtimeExternals
+}
+
+// SetRuntimeExternals stores the package prefixes bundled into the shared runtime.
+func (r *Registry) SetRuntimeExternals(externals []string) {
+	r.mu.Lock()
+	r.runtimeExternals = externals
+	r.mu.Unlock()
+}
+
+// DynamicImportTargets returns the specific module specifiers found in
+// dynamic import() calls within thin modules.
+func (r *Registry) DynamicImportTargets() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.dynamicImportTargets
+}
+
+// SetDynamicImportTargets stores the dynamic import target specifiers.
+func (r *Registry) SetDynamicImportTargets(targets []string) {
+	r.mu.Lock()
+	r.dynamicImportTargets = targets
 	r.mu.Unlock()
 }
 
@@ -262,6 +314,13 @@ func (r *Registry) LoadSourceDir(dir string) error {
 			return fmt.Errorf("building shared runtime: %w", err)
 		}
 		r.SetSharedRuntime(rt)
+	}
+
+	r.SetRuntimeExternals(externals)
+
+	targets := extractDynamicImportTargets(modules)
+	if len(targets) > 0 {
+		r.SetDynamicImportTargets(targets)
 	}
 
 	modules = RewriteModuleImports(modules, externals)

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -171,11 +171,11 @@ func (r *Registry) SetSharedRuntime(source string) {
 	r.mu.Unlock()
 }
 
-// RuntimeExternals returns the package prefixes bundled into the shared runtime.
+// RuntimeExternals returns a copy of the package prefixes bundled into the shared runtime.
 func (r *Registry) RuntimeExternals() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.runtimeExternals
+	return append([]string(nil), r.runtimeExternals...)
 }
 
 // SetRuntimeExternals stores the package prefixes bundled into the shared runtime.
@@ -185,12 +185,12 @@ func (r *Registry) SetRuntimeExternals(externals []string) {
 	r.mu.Unlock()
 }
 
-// DynamicImportTargets returns the specific module specifiers found in
+// DynamicImportTargets returns a copy of the module specifiers found in
 // dynamic import() calls within thin modules.
 func (r *Registry) DynamicImportTargets() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.dynamicImportTargets
+	return append([]string(nil), r.dynamicImportTargets...)
 }
 
 // SetDynamicImportTargets stores the dynamic import target specifiers.

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -66,7 +66,7 @@ func NewRegistry() *Registry {
 // LoadDir loads all .golit.module.js files from a directory.
 // If a _runtime.golit.module.js file is present, it is loaded as the shared runtime.
 // Tag names are discovered via a regex pre-pass. Dynamic import() targets in
-// the thin modules are collected to populate runtime externals.
+// the thin modules are collected and stored as dynamic import targets.
 func (r *Registry) LoadDir(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -45,6 +45,10 @@ type Registry struct {
 	// can resolve them at runtime.
 	dynamicImportTargets []string
 
+	// baseDir is the directory from which modules were loaded, used to
+	// resolve dynamic import targets relative to the correct node_modules.
+	baseDir string
+
 	// unregistered tracks custom element tags found but not in the registry
 	unregistered map[string]bool
 
@@ -68,6 +72,9 @@ func NewRegistry() *Registry {
 // Tag names are discovered via a regex pre-pass. Dynamic import() targets in
 // the thin modules are collected and stored as dynamic import targets.
 func (r *Registry) LoadDir(dir string) error {
+	absDir, _ := filepath.Abs(dir)
+	r.SetBaseDir(absDir)
+
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("reading modules directory %s: %w", dir, err)
@@ -200,6 +207,20 @@ func (r *Registry) SetDynamicImportTargets(targets []string) {
 	r.mu.Unlock()
 }
 
+// BaseDir returns the directory from which modules were loaded.
+func (r *Registry) BaseDir() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.baseDir
+}
+
+// SetBaseDir stores the base directory for module resolution.
+func (r *Registry) SetBaseDir(dir string) {
+	r.mu.Lock()
+	r.baseDir = dir
+	r.mu.Unlock()
+}
+
 // Has returns true if a module is registered for the given tag name.
 func (r *Registry) Has(tagName string) bool {
 	r.mu.RLock()
@@ -267,6 +288,9 @@ func (r *Registry) ProcessedPaths() []string {
 // LoadSourceDir bundles all .js/.ts files in a directory tree as thin ES modules
 // and registers them. Also builds and registers the shared runtime.
 func (r *Registry) LoadSourceDir(dir string) error {
+	absDir, _ := filepath.Abs(dir)
+	r.SetBaseDir(absDir)
+
 	var paths []string
 	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/pkg/transformer/transform.go
+++ b/pkg/transformer/transform.go
@@ -172,6 +172,9 @@ func TransformDir(dir string, opts Options) (*Result, error) {
 	for _, target := range registry.DynamicImportTargets() {
 		modPath, err := jsengine.ResolveModulePath(target, dir)
 		if err != nil {
+			if opts.Verbose {
+				fmt.Fprintf(os.Stderr, "golit: warning: could not resolve dynamic import target %s: %v\n", target, err)
+			}
 			continue
 		}
 		bundle, err := jsengine.BundlePreload(modPath, target)

--- a/pkg/transformer/transform.go
+++ b/pkg/transformer/transform.go
@@ -280,14 +280,14 @@ func TransformDir(dir string, opts Options) (*Result, error) {
 	return result, nil
 }
 
-func initEngine(preloadBundles []string, preloadModules []string, runtimeExternals ...[]string) (*jsengine.Engine, error) {
+func initEngine(preloadBundles []string, preloadModules []string, runtimeExternals []string) (*jsengine.Engine, error) {
 	engine, err := jsengine.NewEngine()
 	if err != nil {
 		return nil, err
 	}
 	engine.SetPreloadModules(preloadModules)
 	if len(runtimeExternals) > 0 {
-		engine.SetRuntimeExternals(runtimeExternals[0])
+		engine.SetRuntimeExternals(runtimeExternals)
 	}
 	for _, pb := range preloadBundles {
 		if err := engine.LoadBundle(pb); err != nil {

--- a/pkg/transformer/transform.go
+++ b/pkg/transformer/transform.go
@@ -168,6 +168,24 @@ func TransformDir(dir string, opts Options) (*Result, error) {
 		}
 	}
 
+	// Bundle dynamic import targets from thin modules as preloaded modules.
+	for _, target := range registry.DynamicImportTargets() {
+		modPath, err := jsengine.ResolveModulePath(target, dir)
+		if err != nil {
+			continue
+		}
+		bundle, err := jsengine.BundlePreload(modPath, target)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "golit: warning: could not bundle dynamic import target %s: %v\n", target, err)
+			continue
+		}
+		preloadBundles = append(preloadBundles, bundle)
+		opts.Preload = append(opts.Preload, target)
+		if opts.Verbose {
+			fmt.Fprintf(os.Stderr, "golit: preloaded dynamic import target %s\n", target)
+		}
+	}
+
 	// ── Pass 1: Discovery (sequential) ──────────────────────────────
 	// Read files once and cache their contents so the render pass
 	// doesn't need to re-read them from disk. Collect all source paths
@@ -259,12 +277,15 @@ func TransformDir(dir string, opts Options) (*Result, error) {
 	return result, nil
 }
 
-func initEngine(preloadBundles []string, preloadModules []string) (*jsengine.Engine, error) {
+func initEngine(preloadBundles []string, preloadModules []string, runtimeExternals ...[]string) (*jsengine.Engine, error) {
 	engine, err := jsengine.NewEngine()
 	if err != nil {
 		return nil, err
 	}
 	engine.SetPreloadModules(preloadModules)
+	if len(runtimeExternals) > 0 {
+		engine.SetRuntimeExternals(runtimeExternals[0])
+	}
 	for _, pb := range preloadBundles {
 		if err := engine.LoadBundle(pb); err != nil {
 			engine.Close()
@@ -275,7 +296,7 @@ func initEngine(preloadBundles []string, preloadModules []string) (*jsengine.Eng
 }
 
 func transformSequential(htmlFiles []string, dir string, registry *jsengine.Registry, opts Options, preloadBundles []string, fileCache map[string][]byte) (*Result, *jsengine.Engine, error) {
-	engine, err := initEngine(preloadBundles, opts.Preload)
+	engine, err := initEngine(preloadBundles, opts.Preload, registry.RuntimeExternals())
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating JS engine: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Make `DiscoverExternalPackages` errors non-fatal: log warnings and return partial results from the metafile instead of aborting (fixes #10)
- Detect dynamic `import()` targets in thin component modules and bundle them as preloaded modules so the QJS engine can resolve them at runtime (fixes #11)
- Extend `shimDynamicImports` to also rewrite dynamic imports for packages bundled into `@golit/runtime`

## Problem

Two bundler bugs prevented golit from working with components that have:

1. **Transitive devDependencies** (e.g. `prism-esm` depends on `@esm-bundle/chai` as a devDep). `golit bundle` would fail entirely if any import in the discovery phase was unresolvable.

2. **Dynamic `import()` of external packages** (e.g. RHDS themable mixin: `const { default: { cssText } } = await import("@rhds/tokens/css/default-theme.css.js")`). These specifiers were left as-is in thin modules but weren't resolvable in the QJS engine, causing components to silently fail to load.

## Approach

**Issue #10:** Change error handling in `DiscoverExternalPackages` from fatal to warning. esbuild's metafile still contains all successfully-resolved packages even when some imports fail.

**Issue #11:** Three-part fix:
- `extractDynamicImportTargets()` scans thin modules for `import("...")` calls to external packages
- Dynamic targets are stored in the registry and bundled as standalone preloaded modules via `BundlePreload`
- `shimDynamicImports` is extended with `shimRuntimeImport` to also handle packages bundled into the shared runtime

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] End-to-end: `golit bundle` succeeds on `@rhds/elements` (which triggers both issues)
- [x] End-to-end: `rh-avatar` (which uses the themable mixin's dynamic CSS import) now SSR's correctly (27 DSD instances)
- [x] No regressions on other components (rh-button: 79 DSD, index: 93 DSD)

Made with [Cursor](https://cursor.com)