### PR TITLE
fix(ssr): emit root lit-part markers for components with empty render (#15)

### DIFF
--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -319,8 +319,9 @@ func (e *Engine) RenderElement(tagName string, attrs map[string]string) (*Render
 
 				let html = '';
 				if (typeof el.render === 'function') {
-					const result = el.render();
-					html = __collectTemplateResult(result);
+					html = __collectTemplateResult(el.render(), true);
+				} else {
+					html = __collectTemplateResult(null, true);
 				}
 
 				let css = '';
@@ -396,7 +397,7 @@ const batchRenderSuffix = `;const results=[];` +
 	`el.setAttribute(key,value);` +
 	`const propName=attributeToProperty(Ctor,key);` +
 	`if(propName){const propConfig=getPropertyConfig(Ctor,propName);el[propName]=coerceValue(value,propConfig);}}` +
-	`let html='';if(typeof el.render==='function'){html=__collectTemplateResult(el.render());}` +
+	`let html='';if(typeof el.render==='function'){html=__collectTemplateResult(el.render(),true);}else{html=__collectTemplateResult(null,true);}` +
 	`let css='';if(globalThis.__cssCache.has(Ctor)){css=globalThis.__cssCache.get(Ctor);}` +
 	`else{if(Ctor.styles){css=extractStyles(Ctor.styles);}` +
 	`else if(Ctor.elementStyles){css=extractStyles(Ctor.elementStyles);}` +

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -297,3 +297,63 @@ func TestEngine_UnregisteredElement(t *testing.T) {
 		t.Error("expected error for unregistered element")
 	}
 }
+
+func TestEngine_RenderElement_EmptyRender_HasRootMarkers(t *testing.T) {
+	source := `
+		import { LitElement } from 'lit';
+		class EmptyEl extends LitElement {}
+		customElements.define('empty-el', EmptyEl);
+	`
+	bundle, err := BundleSource(source)
+	if err != nil {
+		t.Fatalf("bundling: %v", err)
+	}
+
+	engine, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	if err := engine.LoadBundle(bundle); err != nil {
+		t.Fatalf("loading bundle: %v", err)
+	}
+
+	result, err := engine.RenderElement("empty-el", map[string]string{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if !strings.Contains(result.HTML, "<!--lit-part-->") {
+		t.Errorf("expected root <!--lit-part--> marker in HTML for component with no render(), got: %q", result.HTML)
+	}
+	if !strings.Contains(result.HTML, "<!--/lit-part-->") {
+		t.Errorf("expected root <!--/lit-part--> marker in HTML for component with no render(), got: %q", result.HTML)
+	}
+}
+
+func TestEngine_RenderElement_WithRender_HasDigestMarkers(t *testing.T) {
+	bundle := bundleMyGreeting(t)
+
+	engine, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	if err := engine.LoadBundle(bundle); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := engine.RenderElement("my-greeting", map[string]string{"name": "Test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result.HTML, "<!--lit-part ") {
+		t.Errorf("expected <!--lit-part DIGEST--> marker in HTML, got: %q", result.HTML[:min(200, len(result.HTML))])
+	}
+	if !strings.Contains(result.HTML, "<!--/lit-part-->") {
+		t.Errorf("expected <!--/lit-part--> closing marker in HTML, got: %q", result.HTML[:min(200, len(result.HTML))])
+	}
+}

--- a/pkg/jsengine/templatecollector.js
+++ b/pkg/jsengine/templatecollector.js
@@ -265,9 +265,13 @@ function classifyBindings(strings) {
 // Main entry point
 // ============================================================
 
-globalThis.__collectTemplateResult = function collectTemplateResult(value) {
-  if (value === null || value === undefined) return '';
-  if (typeof value === 'symbol') return '';
+globalThis.__collectTemplateResult = function collectTemplateResult(value, isRoot) {
+  if (value === null || value === undefined) {
+    return isRoot ? '<!--lit-part--><!--/lit-part-->' : '';
+  }
+  if (typeof value === 'symbol') {
+    return isRoot ? '<!--lit-part--><!--/lit-part-->' : '';
+  }
   if (typeof value === 'string') return escapeHTML(value);
   if (typeof value === 'number') return String(value);
   if (typeof value === 'boolean') return value ? 'true' : '';


### PR DESCRIPTION
## Summary

Components that inherit LitElement's default `render()` (which returns `noChange` / Symbol) had no `<!--lit-part-->` markers in their Declarative Shadow DOM output. Lit's hydration code requires at least one root part marker to be present in every shadow root it manages.

## Problem

`rh-navigation-primary-overlay` (and any component without a custom `render()`) was producing:

```html
<template shadowrootmode="open">
  <style>...</style>
</template>
```

Lit's hydration threw:
```
There should be exactly one root part in a render container,
but we didn't find any in rh-navigation-primary-overlay's shadow root.
```

## Fix

- `templatecollector.js`: `__collectTemplateResult` now accepts an `isRoot` parameter. When `true` and the value is `null`/`undefined`/Symbol, it returns `<!--lit-part--><!--/lit-part-->` instead of empty string.
- `engine.go`: Both `RenderElement` (single render) and `batchRenderSuffix` (batch render used by transform) pass `isRoot=true` and emit empty markers when `render()` doesn't exist.

Now produces:

```html
<template shadowrootmode="open">
  <style>...</style>
  <!--lit-part--><!--/lit-part-->
</template>
```

## Note

This is a partial fix for #15. The full `templatecollector.js` already implements the Lit hydration marker protocol (digests, lit-node indices, binding classification). This commit fixes the specific case of components with empty/no render output.

## Test plan

- [x] All existing tests pass
- [x] `golit render` produces markers for `rh-navigation-primary-overlay`
- [x] Full site build (`hugo-rhds`) includes markers in overlay's shadow root
- [x] Verified `rh-button` and other components with render() still produce full markers

Made with [Cursor](https://cursor.com)