### PR TITLE
fix(bundler): register dynamic import targets as standalone QJS modules (#19)

### DIFF
--- a/pkg/jsengine/bundler.go
+++ b/pkg/jsengine/bundler.go
@@ -427,6 +427,13 @@ func buildPlugins(opt BundleOptions) []api.Plugin {
 	}
 }
 
+// BundleStandaloneModule bundles a module file into a self-contained ES module
+// with exports preserved. Used for registering dynamic import targets as named
+// QJS modules so import("specifier") resolves natively.
+func BundleStandaloneModule(modulePath string) (string, error) {
+	return bundleComponentRaw(modulePath, BundleOptions{})
+}
+
 // BundleSource bundles a component from inline JS/TS source code (no file on disk).
 // Uses esbuild's Stdin option instead of EntryPoints.
 func BundleSource(source string, opts ...BundleOptions) (string, error) {

--- a/pkg/jsengine/bundler.go
+++ b/pkg/jsengine/bundler.go
@@ -866,9 +866,27 @@ func rewriteImportLine(line string, externals []string) (string, bool) {
 	specifier := specPart[1 : 1+endQuote]
 
 	if matchesExternals(specifier, externals) {
+		if isDefaultImport(line[:fromIdx]) {
+			return "", false
+		}
 		return line[:fromIdx] + " from " + string(quote) + "@golit/runtime" + string(quote) + ";", true
 	}
 	return "", false
+}
+
+// isDefaultImport checks if the import clause is a default import
+// (e.g. "import styles" or "import foo, { bar }").
+func isDefaultImport(importClause string) bool {
+	trimmed := strings.TrimSpace(importClause)
+	trimmed = strings.TrimPrefix(trimmed, "import ")
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "*") {
+		return false
+	}
+	return true
 }
 
 func rewriteSideEffectImport(line string, externals []string) (string, bool) {
@@ -1026,6 +1044,31 @@ func buildRuntimeEntryFromModules(modules map[string]string) string {
 // Matches patterns like: import("@rhds/tokens/css/default-theme.css.js")
 func ExtractDynamicImportTargets(modules map[string]string) []string {
 	return extractDynamicImportTargets(modules)
+}
+
+// ExtractUnrewrittenImports scans rewritten thin module sources for static
+// imports that still reference external specifiers (not @golit/runtime, not
+// relative). These are default imports that were intentionally not rewritten
+// and need standalone module registration.
+func ExtractUnrewrittenImports(modules map[string]string) []string {
+	seen := make(map[string]bool)
+	var specifiers []string
+
+	for _, source := range modules {
+		for _, line := range strings.Split(source, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if !strings.HasPrefix(trimmed, "import ") || !strings.Contains(trimmed, " from ") {
+				continue
+			}
+			spec := extractFromSpecifier(trimmed)
+			if spec != "" && !isLocalOrRuntime(spec) && !seen[spec] {
+				seen[spec] = true
+				specifiers = append(specifiers, spec)
+			}
+		}
+	}
+	sort.Strings(specifiers)
+	return specifiers
 }
 
 func extractDynamicImportTargets(modules map[string]string) []string {

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -286,10 +285,9 @@ func (e *Engine) LoadBundleForTag(tagName string, registry *Registry) (bool, err
 	for specifier, modSource := range registry.DynamicModules() {
 		if !e.loaded[specifier] {
 			if err := e.LoadModule(specifier, modSource); err != nil {
-				fmt.Fprintf(os.Stderr, "golit: warning: loading dynamic module %s: %v\n", specifier, err)
-			} else {
-				e.loaded[specifier] = true
+				return false, fmt.Errorf("loading dynamic module %s for <%s>: %w", specifier, tagName, err)
 			}
+			e.loaded[specifier] = true
 		}
 	}
 

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -275,6 +276,16 @@ func (e *Engine) LoadBundleForTag(tagName string, registry *Registry) (bool, err
 
 	if ext := registry.RuntimeExternals(); len(ext) > 0 && len(e.runtimeExternals) == 0 {
 		e.runtimeExternals = ext
+	}
+
+	for specifier, modSource := range registry.DynamicModules() {
+		if !e.loaded[specifier] {
+			if err := e.LoadModule(specifier, modSource); err != nil {
+				fmt.Fprintf(os.Stderr, "golit: warning: loading dynamic module %s: %v\n", specifier, err)
+			} else {
+				e.loaded[specifier] = true
+			}
+		}
 	}
 
 	if err := e.EvalModule(tagName+".js", source); err != nil {

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -230,6 +230,8 @@ func (e *Engine) shimDynamicImports(code string) string {
 
 // shimRuntimeImport checks if a dynamic import() at the given position
 // matches a runtime external package and rewrites it to import("@golit/runtime").
+// Skips specifiers that have a standalone module registered (e.loaded),
+// allowing QJS native module resolution to handle them instead.
 func (e *Engine) shimRuntimeImport(code string, matchStart int) (string, int) {
 	for _, quote := range []byte{'"', '\''} {
 		prefix := `import(` + string(quote)
@@ -243,6 +245,9 @@ func (e *Engine) shimRuntimeImport(code string, matchStart int) (string, int) {
 			continue
 		}
 		specifier := code[matchStart+len(prefix) : matchStart+len(prefix)+end]
+		if e.loaded[specifier] {
+			return "", 0
+		}
 		if matchesExternals(specifier, e.runtimeExternals) {
 			full := code[matchStart : matchStart+len(prefix)+end+len(closeStr)]
 			rewritten := `import(` + string(quote) + `@golit/runtime` + string(quote) + `)/*golit-runtime:` + full + `*/`

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -282,13 +282,16 @@ func (e *Engine) LoadBundleForTag(tagName string, registry *Registry) (bool, err
 		e.runtimeExternals = ext
 	}
 
-	for specifier, modSource := range registry.DynamicModules() {
-		if !e.loaded[specifier] {
-			if err := e.LoadModule(specifier, modSource); err != nil {
-				return false, fmt.Errorf("loading dynamic module %s for <%s>: %w", specifier, tagName, err)
+	if !e.loaded["@golit/dynamic-modules"] {
+		for specifier, modSource := range registry.DynamicModules() {
+			if !e.loaded[specifier] {
+				if err := e.LoadModule(specifier, modSource); err != nil {
+					return false, fmt.Errorf("loading dynamic module %s for <%s>: %w", specifier, tagName, err)
+				}
+				e.loaded[specifier] = true
 			}
-			e.loaded[specifier] = true
 		}
+		e.loaded["@golit/dynamic-modules"] = true
 	}
 
 	if err := e.EvalModule(tagName+".js", source); err != nil {

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -1,8 +1,11 @@
 package jsengine
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/fastschema/qjs"
 )
 
 func bundleMyGreeting(t *testing.T) string {
@@ -355,5 +358,55 @@ func TestEngine_RenderElement_WithRender_HasDigestMarkers(t *testing.T) {
 	}
 	if !strings.Contains(result.HTML, "<!--/lit-part-->") {
 		t.Errorf("expected <!--/lit-part--> closing marker in HTML, got: %q", result.HTML[:min(200, len(result.HTML))])
+	}
+}
+
+func TestBundleStandaloneModule_DefaultExport(t *testing.T) {
+	esm, err := BundleStandaloneModule("../../testdata/sources/css-module.js")
+	if err != nil {
+		t.Fatalf("bundling standalone module: %v", err)
+	}
+
+	if !strings.Contains(esm, "export") {
+		t.Error("standalone module should preserve ESM exports")
+	}
+
+	engine, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	if err := engine.LoadModule("test-css-module", esm); err != nil {
+		t.Fatalf("loading module: %v", err)
+	}
+
+	script := `
+		import mod from "test-css-module";
+		globalThis.__testResult = JSON.stringify({
+			hasDefault: mod !== undefined,
+			cssText: mod ? mod.cssText : "",
+		});
+	`
+	if _, err := engine.ctx.Eval("test-import.js", qjs.Code(script), qjs.TypeModule()); err != nil {
+		t.Fatalf("eval module: %v", err)
+	}
+	result, err := engine.ctx.Eval("read-result.js", qjs.Code(`globalThis.__testResult`))
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+
+	var output struct {
+		HasDefault bool   `json:"hasDefault"`
+		CSSText    string `json:"cssText"`
+	}
+	if err := json.Unmarshal([]byte(result.String()), &output); err != nil {
+		t.Fatalf("parsing result: %v (raw: %s)", err, result.String())
+	}
+	if !output.HasDefault {
+		t.Fatal("standalone module default export was not accessible via import")
+	}
+	if !strings.Contains(output.CSSText, "color: red") {
+		t.Errorf("expected cssText to contain 'color: red', got: %q", output.CSSText)
 	}
 }

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -41,27 +41,27 @@ func NewEnginePool(size int) (*EnginePool, error) {
 // After this call the registry must be treated as read-only.
 func (p *EnginePool) PreloadAll(registry *Registry, preloadModules []string, preloadBundles ...string) error {
 	tags := registry.TagNames()
+	runtimeExternals := registry.RuntimeExternals()
+	sharedRuntime := registry.SharedRuntime()
+	dynamicModules := registry.DynamicModules()
 
 	drained := make([]*Engine, 0, p.size)
 
 	for i := 0; i < p.size; i++ {
 		e := <-p.engines
 		e.SetPreloadModules(preloadModules)
-		e.SetRuntimeExternals(registry.RuntimeExternals())
+		e.SetRuntimeExternals(runtimeExternals)
 		for _, pb := range preloadBundles {
 			_ = e.LoadBundle(pb)
 		}
-		// Load shared runtime once per engine before any components.
-		if rt := registry.SharedRuntime(); rt != "" && !e.loaded["@golit/runtime"] {
-			if err := e.LoadModule("@golit/runtime", rt); err != nil {
+		if sharedRuntime != "" && !e.loaded["@golit/runtime"] {
+			if err := e.LoadModule("@golit/runtime", sharedRuntime); err != nil {
 				fmt.Fprintf(os.Stderr, "golit: warning: loading shared runtime: %v\n", err)
 			} else {
 				e.loaded["@golit/runtime"] = true
 			}
 		}
-		// Register dynamic modules as named QJS modules so native
-		// import("specifier") resolution works for CSS/JS modules.
-		for specifier, source := range registry.DynamicModules() {
+		for specifier, source := range dynamicModules {
 			if !e.loaded[specifier] {
 				if err := e.LoadModule(specifier, source); err != nil {
 					fmt.Fprintf(os.Stderr, "golit: warning: loading dynamic module %s: %v\n", specifier, err)

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -94,6 +94,17 @@ func (p *EnginePool) PreloadAll(registry *Registry, preloadModules []string, pre
 				e.loaded["@golit/runtime"] = true
 			}
 		}
+		// Register dynamic modules as named QJS modules so native
+		// import("specifier") resolution works for CSS/JS modules.
+		for specifier, source := range registry.DynamicModules() {
+			if !e.loaded[specifier] {
+				if err := e.LoadModule(specifier, source); err != nil {
+					fmt.Fprintf(os.Stderr, "golit: warning: loading dynamic module %s: %v\n", specifier, err)
+				} else {
+					e.loaded[specifier] = true
+				}
+			}
+		}
 		for _, tag := range tags {
 			if _, err := e.LoadBundleForTag(tag, registry); err != nil {
 				fmt.Fprintf(os.Stderr, "golit: warning: %v\n", err)

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -42,49 +42,14 @@ func NewEnginePool(size int) (*EnginePool, error) {
 func (p *EnginePool) PreloadAll(registry *Registry, preloadModules []string, preloadBundles ...string) error {
 	tags := registry.TagNames()
 
-	// Bundle dynamic import targets that aren't already in preloadModules.
-	// When called from transform.go, targets are pre-bundled and passed via
-	// preloadBundles/preloadModules. When called from serve.go, this is the
-	// only place they get bundled.
-	already := make(map[string]bool, len(preloadModules))
-	for _, m := range preloadModules {
-		already[m] = true
-	}
-	var dynamicBundles []string
-	allPreloadModules := append([]string(nil), preloadModules...)
-	for _, target := range registry.DynamicImportTargets() {
-		if already[target] {
-			continue
-		}
-		baseDir := registry.BaseDir()
-		if baseDir == "" {
-			baseDir = "."
-		}
-		modPath, err := ResolveModulePath(target, baseDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "golit: warning: cannot resolve dynamic import target %s: %v\n", target, err)
-			continue
-		}
-		bundle, err := BundlePreload(modPath, target)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "golit: warning: cannot bundle dynamic import target %s: %v\n", target, err)
-			continue
-		}
-		dynamicBundles = append(dynamicBundles, bundle)
-		allPreloadModules = append(allPreloadModules, target)
-	}
-
 	drained := make([]*Engine, 0, p.size)
 
 	for i := 0; i < p.size; i++ {
 		e := <-p.engines
-		e.SetPreloadModules(allPreloadModules)
+		e.SetPreloadModules(preloadModules)
 		e.SetRuntimeExternals(registry.RuntimeExternals())
 		for _, pb := range preloadBundles {
 			_ = e.LoadBundle(pb)
-		}
-		for _, db := range dynamicBundles {
-			_ = e.LoadBundle(db)
 		}
 		// Load shared runtime once per engine before any components.
 		if rt := registry.SharedRuntime(); rt != "" && !e.loaded["@golit/runtime"] {

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -41,9 +41,14 @@ type Registry struct {
 
 	// dynamicImportTargets lists specific module specifiers that appear in
 	// dynamic import() calls in thin modules (e.g. "@rhds/tokens/css/default-theme.css.js").
-	// These need to be bundled as standalone preloaded modules so the engine
+	// These need to be bundled as standalone modules so the engine
 	// can resolve them at runtime.
 	dynamicImportTargets []string
+
+	// dynamicModules maps specifier -> raw ESM source for modules that
+	// need to be registered in QJS under their original specifier name
+	// so dynamic import() calls resolve natively.
+	dynamicModules map[string]string
 
 	// baseDir is the directory from which modules were loaded, used to
 	// resolve dynamic import targets relative to the correct node_modules.
@@ -115,6 +120,18 @@ func (r *Registry) LoadDir(dir string) error {
 		targets := extractDynamicImportTargets(moduleSources)
 		if len(targets) > 0 {
 			r.SetDynamicImportTargets(targets)
+			for _, target := range targets {
+				modPath, err := ResolveModulePath(target, absDir)
+				if err != nil {
+					continue
+				}
+				esm, err := BundleStandaloneModule(modPath)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "golit: warning: could not bundle dynamic module %s: %v\n", target, err)
+					continue
+				}
+				r.SetDynamicModule(target, esm)
+			}
 		}
 	}
 
@@ -204,6 +221,31 @@ func (r *Registry) DynamicImportTargets() []string {
 func (r *Registry) SetDynamicImportTargets(targets []string) {
 	r.mu.Lock()
 	r.dynamicImportTargets = targets
+	r.mu.Unlock()
+}
+
+// DynamicModules returns a copy of the specifier -> ESM source map for
+// modules that should be registered as named QJS modules.
+func (r *Registry) DynamicModules() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.dynamicModules == nil {
+		return nil
+	}
+	cp := make(map[string]string, len(r.dynamicModules))
+	for k, v := range r.dynamicModules {
+		cp[k] = v
+	}
+	return cp
+}
+
+// SetDynamicModule registers a standalone ES module under its specifier name.
+func (r *Registry) SetDynamicModule(specifier, source string) {
+	r.mu.Lock()
+	if r.dynamicModules == nil {
+		r.dynamicModules = make(map[string]string)
+	}
+	r.dynamicModules[specifier] = source
 	r.mu.Unlock()
 }
 

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -133,6 +133,23 @@ func (r *Registry) LoadDir(dir string) error {
 				r.SetDynamicModule(target, esm)
 			}
 		}
+
+		unrewritten := ExtractUnrewrittenImports(moduleSources)
+		for _, spec := range unrewritten {
+			if r.dynamicModules != nil && r.dynamicModules[spec] != "" {
+				continue
+			}
+			modPath, err := ResolveModulePath(spec, absDir)
+			if err != nil {
+				continue
+			}
+			esm, err := BundleStandaloneModule(modPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "golit: warning: could not bundle standalone module %s: %v\n", spec, err)
+				continue
+			}
+			r.SetDynamicModule(spec, esm)
+		}
 	}
 
 	return nil
@@ -390,6 +407,23 @@ func (r *Registry) LoadSourceDir(dir string) error {
 	}
 
 	modules = RewriteModuleImports(modules, externals)
+
+	// After rewriting, find default imports that kept their original specifier
+	// (not rewritten to @golit/runtime) and bundle them as standalone modules.
+	unrewritten := ExtractUnrewrittenImports(modules)
+	for _, spec := range unrewritten {
+		modPath, err := ResolveModulePath(spec, dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "golit: warning: could not resolve unrewritten import %s: %v\n", spec, err)
+			continue
+		}
+		esm, err := BundleStandaloneModule(modPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "golit: warning: could not bundle standalone module %s: %v\n", spec, err)
+			continue
+		}
+		r.SetDynamicModule(spec, esm)
+	}
 
 	for _, source := range modules {
 		if tagName, ok := discoverTagNameFast(source); ok {

--- a/pkg/jsengine/registry.go
+++ b/pkg/jsengine/registry.go
@@ -123,6 +123,7 @@ func (r *Registry) LoadDir(dir string) error {
 			for _, target := range targets {
 				modPath, err := ResolveModulePath(target, absDir)
 				if err != nil {
+					fmt.Fprintf(os.Stderr, "golit: warning: could not resolve dynamic module %s from %s: %v\n", target, absDir, err)
 					continue
 				}
 				esm, err := BundleStandaloneModule(modPath)

--- a/pkg/transformer/transform.go
+++ b/pkg/transformer/transform.go
@@ -168,27 +168,6 @@ func TransformDir(dir string, opts Options) (*Result, error) {
 		}
 	}
 
-	// Bundle dynamic import targets from thin modules as preloaded modules.
-	for _, target := range registry.DynamicImportTargets() {
-		modPath, err := jsengine.ResolveModulePath(target, dir)
-		if err != nil {
-			if opts.Verbose {
-				fmt.Fprintf(os.Stderr, "golit: warning: could not resolve dynamic import target %s: %v\n", target, err)
-			}
-			continue
-		}
-		bundle, err := jsengine.BundlePreload(modPath, target)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "golit: warning: could not bundle dynamic import target %s: %v\n", target, err)
-			continue
-		}
-		preloadBundles = append(preloadBundles, bundle)
-		opts.Preload = append(opts.Preload, target)
-		if opts.Verbose {
-			fmt.Fprintf(os.Stderr, "golit: preloaded dynamic import target %s\n", target)
-		}
-	}
-
 	// ── Pass 1: Discovery (sequential) ──────────────────────────────
 	// Read files once and cache their contents so the render pass
 	// doesn't need to re-read them from disk. Collect all source paths

--- a/testdata/sources/css-module.js
+++ b/testdata/sources/css-module.js
@@ -1,0 +1,3 @@
+const cssText = ":host { color: red; }";
+const sheet = { cssText, _$cssResult$: true, toString() { return cssText; } };
+export default sheet;


### PR DESCRIPTION
## Summary

Register each dynamic import target as a standalone ES module in QJS under its original specifier name, so `import("@rhds/tokens/css/default-theme.css.js")` resolves natively through QJS module resolution.

## Problem

The shared runtime uses `export * from 'pkg'` which per the ES module spec does not re-export `default` exports. Components using the RHDS themable mixin pattern:

```js
const { default: { cssText } } = await import("@rhds/tokens/css/default-theme.css.js");
```

...fail with `SyntaxError: Could not find export 'default' in module '@golit/runtime'` because the `shimRuntimeImport` fallback rewrites the import to `@golit/runtime` which lacks the default.

## Approach

Instead of trying to expose defaults through the shared runtime, bundle each dynamic import target independently and register it as a named QJS module:

- `BundleStandaloneModule()` -- new function that bundles a file with ESM exports preserved
- `Registry.DynamicModules()` -- stores specifier -> ESM source mappings
- `LoadDir` bundles and stores dynamic targets during module loading
- `EnginePool.PreloadAll` and `Engine.LoadBundleForTag` register them via `LoadModule(specifier, source)`

This means `import("@rhds/tokens/css/default-theme.css.js")` resolves through QJS's native module system with no shimming needed.

## Test plan

- [x] All existing tests pass
- [x] `golit bundle` + `golit transform` on hugo-rhds: rh-avatar (themable mixin) renders with 27 DSD instances
- [x] Dynamic module `@rhds/tokens/css/default-theme.css.js` and 8 prism-esm component modules successfully preloaded

Closes #19

Made with [Cursor](https://cursor.com)