### PR TITLE
feat(serve): add Server-Timing header with render duration and pool utilization

### DIFF
--- a/cmd/golit/serve.go
+++ b/cmd/golit/serve.go
@@ -165,14 +165,15 @@ func runServe(args []string) error {
 		pool.Put(engine)
 		dur := time.Since(start)
 
+		w.Header().Set("Server-Timing", fmt.Sprintf(
+			`render;dur=%.1f, pool;desc="%d/%d busy"`,
+			float64(dur.Microseconds())/1000.0, active, pool.Size()))
+
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Server-Timing", fmt.Sprintf(
-			`render;dur=%.1f, pool;desc="%d/%d busy"`,
-			float64(dur.Microseconds())/1000.0, active, pool.Size()))
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(out))
 	})

--- a/cmd/golit/serve.go
+++ b/cmd/golit/serve.go
@@ -158,15 +158,21 @@ func runServe(args []string) error {
 			return
 		}
 
+		start := time.Now()
 		engine := pool.Get()
+		active := pool.Size() - pool.Available()
 		out, err := transformer.RenderHTMLWithEngine(string(body), engine, registry, ignoredMap)
 		pool.Put(engine)
+		dur := time.Since(start)
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Server-Timing", fmt.Sprintf(
+			`render;dur=%.1f, pool;desc="%d/%d busy"`,
+			float64(dur.Microseconds())/1000.0, active, pool.Size()))
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(out))
 	})

--- a/pkg/jsengine/pool.go
+++ b/pkg/jsengine/pool.go
@@ -99,6 +99,11 @@ func (p *EnginePool) Size() int {
 	return p.size
 }
 
+// Available returns the number of idle engines currently in the pool.
+func (p *EnginePool) Available() int {
+	return len(p.engines)
+}
+
 // Close releases all engines in the pool.
 func (p *EnginePool) Close() {
 	close(p.engines)

--- a/pkg/jsengine/pool_test.go
+++ b/pkg/jsengine/pool_test.go
@@ -69,6 +69,38 @@ func TestEnginePool_PreloadAndRender(t *testing.T) {
 	}
 }
 
+func TestEnginePool_Available(t *testing.T) {
+	pool, err := NewEnginePool(3)
+	if err != nil {
+		t.Fatalf("NewEnginePool: %v", err)
+	}
+	defer pool.Close()
+
+	if got := pool.Available(); got != 3 {
+		t.Fatalf("Available = %d, want 3 (all idle)", got)
+	}
+
+	e1 := pool.Get()
+	if got := pool.Available(); got != 2 {
+		t.Fatalf("Available after 1 Get = %d, want 2", got)
+	}
+
+	e2 := pool.Get()
+	if got := pool.Available(); got != 1 {
+		t.Fatalf("Available after 2 Gets = %d, want 1", got)
+	}
+
+	pool.Put(e1)
+	if got := pool.Available(); got != 2 {
+		t.Fatalf("Available after Put = %d, want 2", got)
+	}
+
+	pool.Put(e2)
+	if got := pool.Available(); got != 3 {
+		t.Fatalf("Available after all returned = %d, want 3", got)
+	}
+}
+
 func TestEnginePool_ConcurrentRender(t *testing.T) {
 	bundle := bundleMyGreeting(t)
 


### PR DESCRIPTION
## Summary

- Adds a [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing) response header to every `POST /render` response, reporting wall-clock render duration and engine pool utilization.
- Adds an `Available()` method to `EnginePool` to expose the number of idle workers.

Example header:

```
Server-Timing: render;dur=42.3, pool;desc="3/16 busy"
```

**`render;dur=42.3`** — milliseconds spent checking out an engine, running `RenderHTMLWithEngine`, and returning the engine to the pool.

**`pool;desc="3/16 busy"`** — how many engine workers were active (including this request) out of the total pool size, captured at the moment the engine was acquired.

### Why

When running `golit serve` with high concurrency (e.g. `-j 16`), there was no way to verify whether parallel workers were actually being utilized or to see per-request render times. This header surfaces both data points using a W3C standard that:

- Appears automatically in browser DevTools (Network > Timing)
- Is readable programmatically by middleware consumers via `res.headers.get('Server-Timing')`
- Adds zero configuration — always present on successful render responses

### Files changed

- `cmd/golit/serve.go` — timing instrumentation around the render call, `Server-Timing` header on response
- `pkg/jsengine/pool.go` — new `Available()` method on `EnginePool`

## Test plan

- [ ] `make build` compiles cleanly
- [ ] Start `golit serve --defs <dir> -j 4`, send a `POST /render`, verify `Server-Timing` header is present with `render;dur=` and `pool;desc=`
- [ ] Send concurrent requests (e.g. via `ab` or `xargs curl`) and verify the busy count increases with concurrency

Made with [Cursor](https://cursor.com)