### PR TITLE
feat(render): support reading HTML fragment from stdin

### DIFF
--- a/cmd/golit/main.go
+++ b/cmd/golit/main.go
@@ -6,6 +6,7 @@
 //	golit bundle <source.ts|js> [--out <file>] [--minify]
 //	golit transform <html-dir> --defs <bundles-dir> [--out <dir>] [--verbose]
 //	golit render --defs <bundles-dir> '<html-fragment>'
+//	echo '<html>' | golit render --defs <bundles-dir>
 //	golit version
 package main
 
@@ -71,6 +72,7 @@ Usage:
   golit compile --defs <bundles-dir> [--out <file.golit.compiled.js>] [--minify]
   golit transform <html-dir> [--defs <dir>] [--compiled <file>] [--sources <dir>] [--importmap <file>] [--out <dir>]
   golit render --defs <bundles-dir> '<html-fragment>'
+  echo '<html>' | golit render --defs <bundles-dir>
   golit render --component-js '<source>' '<html-fragment>'
   golit serve --defs <bundles-dir> [--listen host:port]
   golit version
@@ -125,6 +127,9 @@ Examples:
 
   # Render a single element
   golit render --defs bundles/ '<my-greeting name="World"></my-greeting>'
+
+  # Pipe large HTML from stdin (avoids ARG_MAX limits)
+  cat page.html | golit render --defs bundles/
 
   # Long-lived SSR (warm Renderer) for middleware integration
   golit serve --defs bundles/ --listen 127.0.0.1:9777

--- a/cmd/golit/render.go
+++ b/cmd/golit/render.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -45,7 +46,20 @@ func runRender(args []string) error {
 		return fmt.Errorf("missing required --defs <dir> or --component-js <source> argument")
 	}
 	if fragment == "" {
-		return fmt.Errorf("missing HTML fragment argument")
+		info, err := os.Stdin.Stat()
+		if err != nil {
+			return fmt.Errorf("checking stdin: %w", err)
+		}
+		if info.Mode()&os.ModeCharDevice == 0 {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("reading stdin: %w", err)
+			}
+			fragment = strings.TrimSpace(string(data))
+		}
+	}
+	if fragment == "" {
+		return fmt.Errorf("missing HTML fragment argument (pass as argument or pipe to stdin)")
 	}
 
 	registry := jsengine.NewRegistry()

--- a/cmd/golit/render.go
+++ b/cmd/golit/render.go
@@ -51,9 +51,13 @@ func runRender(args []string) error {
 			return fmt.Errorf("checking stdin: %w", err)
 		}
 		if info.Mode()&os.ModeCharDevice == 0 {
-			data, err := io.ReadAll(os.Stdin)
+			const maxStdin = 32 << 20 // 32 MiB
+			data, err := io.ReadAll(io.LimitReader(os.Stdin, maxStdin+1))
 			if err != nil {
 				return fmt.Errorf("reading stdin: %w", err)
+			}
+			if len(data) > maxStdin {
+				return fmt.Errorf("stdin input too large (max %d MiB)", maxStdin>>20)
 			}
 			fragment = strings.TrimSpace(string(data))
 		}

--- a/cmd/golit/render_test.go
+++ b/cmd/golit/render_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -11,7 +12,11 @@ import (
 
 func buildGolit(t *testing.T) string {
 	t.Helper()
-	bin := filepath.Join(t.TempDir(), "golit")
+	name := "golit"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
 	cmd := exec.Command("go", "build", "-o", bin, ".")
 	cmd.Dir = filepath.Join(projectRoot(t), "cmd", "golit")
 	out, err := cmd.CombinedOutput()
@@ -157,6 +162,7 @@ func TestRender_NoInputError(t *testing.T) {
 	bundleDir := buildTestBundles(t)
 
 	cmd := exec.Command(bin, "render", "--defs", bundleDir)
+	cmd.Stdin = strings.NewReader("")
 	var stderrBuf strings.Builder
 	cmd.Stderr = &stderrBuf
 	err := cmd.Run()

--- a/cmd/golit/render_test.go
+++ b/cmd/golit/render_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zeroedin/golit/pkg/jsengine"
+)
+
+func buildGolit(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "golit")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = filepath.Join(projectRoot(t), "cmd", "golit")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building golit: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func buildTestBundles(t *testing.T) string {
+	t.Helper()
+	root := projectRoot(t)
+	bundleDir := t.TempDir()
+
+	sources := []string{
+		filepath.Join(root, "testdata", "sources", "my-greeting.js"),
+	}
+
+	nodeModulesDir := jsengine.FindNodeModules(sources[0])
+	externals, err := jsengine.DiscoverExternalPackages(sources, nodeModulesDir)
+	if err != nil {
+		t.Fatalf("discovering externals: %v", err)
+	}
+
+	modules, err := jsengine.BundleComponentModules(sources, jsengine.BundleOptions{
+		ExternalPackages: externals,
+	})
+	if err != nil {
+		t.Fatalf("bundling modules: %v", err)
+	}
+
+	if nodeModulesDir != "" {
+		rt, err := jsengine.BundleSharedRuntime(nodeModulesDir, modules)
+		if err != nil {
+			t.Fatalf("building shared runtime: %v", err)
+		}
+		if err := jsengine.SaveBundle(rt, filepath.Join(bundleDir, "_runtime.golit.module.js")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	modules = jsengine.RewriteModuleImports(modules, externals)
+
+	for srcPath, mod := range modules {
+		base := filepath.Base(srcPath)
+		ext := filepath.Ext(base)
+		outName := strings.TrimSuffix(base, ext) + ".golit.module.js"
+		if err := jsengine.SaveBundle(mod, filepath.Join(bundleDir, outName)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return bundleDir
+}
+
+func TestRender_StdinPipe(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	cmd := exec.Command(bin, "render", "--defs", bundleDir)
+	cmd.Stdin = strings.NewReader(`<my-greeting name="Stdin"></my-greeting>`)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		t.Fatalf("render via stdin failed: %v\nstderr: %s", err, stderr)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, `shadowrootmode="open"`) {
+		t.Errorf("missing DSD in stdin output:\n%s", output)
+	}
+	if !strings.Contains(output, "Stdin") {
+		t.Errorf("missing name in stdin output:\n%s", output)
+	}
+}
+
+func TestRender_StdinLargeFragment(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	var sb strings.Builder
+	for i := 0; i < 100; i++ {
+		sb.WriteString(`<my-greeting name="Item"></my-greeting>`)
+	}
+	largeInput := sb.String()
+
+	cmd := exec.Command(bin, "render", "--defs", bundleDir)
+	cmd.Stdin = strings.NewReader(largeInput)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		t.Fatalf("render large stdin failed: %v\nstderr: %s", err, stderr)
+	}
+
+	output := string(out)
+	count := strings.Count(output, `shadowrootmode="open"`)
+	if count < 100 {
+		t.Errorf("expected >= 100 DSD templates, got %d", count)
+	}
+}
+
+func TestRender_ArgTakesPrecedenceOverStdin(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	cmd := exec.Command(bin, "render", "--defs", bundleDir, `<my-greeting name="Arg"></my-greeting>`)
+	cmd.Stdin = strings.NewReader(`<my-greeting name="Stdin"></my-greeting>`)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		t.Fatalf("render with arg+stdin failed: %v\nstderr: %s", err, stderr)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "Arg") {
+		t.Errorf("arg should take precedence, but 'Arg' not in output:\n%s", output)
+	}
+	if strings.Contains(output, "Stdin") {
+		t.Errorf("stdin should be ignored when arg is provided, but 'Stdin' found in output:\n%s", output)
+	}
+}
+
+func TestRender_NoInputError(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	cmd := exec.Command(bin, "render", "--defs", bundleDir)
+	var stderrBuf strings.Builder
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected error when no fragment and no stdin pipe")
+	}
+	if !strings.Contains(stderrBuf.String(), "missing HTML fragment") {
+		t.Errorf("expected 'missing HTML fragment' error, got: %s", stderrBuf.String())
+	}
+}
+
+func TestRender_StdinWithWhitespace(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	cmd := exec.Command(bin, "render", "--defs", bundleDir)
+	cmd.Stdin = strings.NewReader("\n  <my-greeting name=\"Trimmed\"></my-greeting>\n\n")
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		t.Fatalf("render stdin with whitespace failed: %v\nstderr: %s", err, stderr)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, `shadowrootmode="open"`) {
+		t.Errorf("missing DSD in trimmed stdin output:\n%s", output)
+	}
+	if !strings.Contains(output, "Trimmed") {
+		t.Errorf("missing name in trimmed stdin output:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds stdin support to `golit render` for piping large HTML fragments that would exceed OS `ARG_MAX` limits
- Auto-detects piped stdin when no positional HTML argument is provided (via `os.ModeCharDevice` check)
- Positional argument takes precedence when both are provided
- Updates usage docs with stdin examples

### Usage

```bash
# Pipe from echo
echo '<my-greeting name="World"></my-greeting>' | golit render --defs bundles/

# Pipe from file
cat page.html | golit render --defs bundles/

# Existing argument syntax still works
golit render --defs bundles/ '<my-greeting name="World"></my-greeting>'
```

Relates to #22 (competitive analysis noted lit-ssr-wasm supports stdio protocol).

## Test plan

- [x] `TestRender_StdinPipe` — basic stdin rendering produces DSD output
- [x] `TestRender_StdinLargeFragment` — 100 elements via stdin (the ARG_MAX scenario)
- [x] `TestRender_ArgTakesPrecedenceOverStdin` — positional arg wins when both provided
- [x] `TestRender_NoInputError` — proper error message when neither source provided
- [x] `TestRender_StdinWithWhitespace` — leading/trailing whitespace is trimmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)