### PR TITLE
feat(serve): add --stdio flag for NUL-delimited stdin/stdout protocol

### DIFF
--- a/cmd/golit/main.go
+++ b/cmd/golit/main.go
@@ -74,7 +74,7 @@ Usage:
   golit render --defs <bundles-dir> '<html-fragment>'
   echo '<html>' | golit render --defs <bundles-dir>
   golit render --component-js '<source>' '<html-fragment>'
-  golit serve --defs <bundles-dir> [--listen host:port]
+  golit serve --defs <bundles-dir> [--listen host:port] [--stdio]
   golit version
 
 Commands:
@@ -85,7 +85,9 @@ Commands:
   transform   Post-process HTML files, expanding custom elements into
               Declarative Shadow DOM using bundled components.
   render      Render a single HTML fragment to stdout.
-  serve       Run HTTP server: POST /render (full HTML) -> transformed HTML; GET /health.
+  serve       Run HTTP or stdio server for warm-pool rendering.
+              HTTP (default): POST /render (full HTML) -> transformed HTML; GET /health.
+              Stdio (--stdio): NUL-delimited stdin/stdout protocol.
   version     Print version information.
 
 Options:
@@ -102,6 +104,7 @@ Options:
   --concurrency, -j  Parallel workers for transform (default: sequential)
                      -j alone uses all CPUs, -j N uses N workers
   --component-js     Inline JS/TS component source for render command (repeatable)
+  --stdio            Use NUL-delimited stdin/stdout instead of HTTP (serve command)
 
 Component Discovery (transform command):
   golit discovers which components to SSR using four modes (combinable):
@@ -133,5 +136,8 @@ Examples:
 
   # Long-lived SSR (warm Renderer) for middleware integration
   golit serve --defs bundles/ --listen 127.0.0.1:9777
+
+  # Stdio mode (NUL-delimited, warm pool, no HTTP)
+  golit serve --defs bundles/ --stdio
 `)
 }

--- a/cmd/golit/serve.go
+++ b/cmd/golit/serve.go
@@ -26,6 +26,7 @@ func runServe(args []string) error {
 		sourcesDir  string
 		listen      = "127.0.0.1:9777"
 		listenFlag  bool
+		stdioMode   bool
 		ignored     []string
 		preload     []string
 		concurrency int
@@ -64,6 +65,8 @@ func runServe(args []string) error {
 			}
 			preload = append(preload, args[i+1])
 			i++
+		case "--stdio":
+			stdioMode = true
 		case "--concurrency", "-j":
 			if i+1 < len(args) {
 				if n, err := strconv.Atoi(args[i+1]); err == nil {
@@ -86,6 +89,10 @@ func runServe(args []string) error {
 		}
 	}
 
+	if stdioMode && listenFlag {
+		return fmt.Errorf("golit serve: --stdio and --listen are mutually exclusive")
+	}
+
 	if defsDir == "" {
 		defsDir = os.Getenv("GOLIT_DEFS")
 	}
@@ -98,7 +105,11 @@ func runServe(args []string) error {
 		}
 	}
 	if concurrency == 0 {
-		concurrency = runtime.NumCPU()
+		if stdioMode {
+			concurrency = 1
+		} else {
+			concurrency = runtime.NumCPU()
+		}
 	}
 
 	registry := jsengine.NewRegistry()
@@ -129,6 +140,10 @@ func runServe(args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "golit serve: initialized %d engine workers\n", concurrency)
+
+	if stdioMode {
+		return runStdio(os.Stdin, os.Stdout, pool, registry, ignoredMap)
+	}
 
 	const maxBody = 32 << 20 // 32 MiB
 

--- a/cmd/golit/serve.go
+++ b/cmd/golit/serve.go
@@ -80,7 +80,6 @@ func runServe(args []string) error {
 			if concurrency == 0 {
 				concurrency = runtime.NumCPU()
 			}
-			i++
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return fmt.Errorf("unknown flag: %s", args[i])

--- a/cmd/golit/stdio.go
+++ b/cmd/golit/stdio.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/zeroedin/golit/pkg/jsengine"
+	"github.com/zeroedin/golit/pkg/transformer"
+)
+
+func runStdio(stdin io.Reader, stdout io.Writer, pool *jsengine.EnginePool, registry *jsengine.Registry, ignored map[string]bool) error {
+	fmt.Fprintf(os.Stderr, "golit serve: stdio mode, reading NUL-delimited requests from stdin\n")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	type readResult struct {
+		data string
+		err  error
+	}
+
+	reader := bufio.NewReader(stdin)
+	writer := bufio.NewWriter(stdout)
+
+	for {
+		ch := make(chan readResult, 1)
+		go func() {
+			data, err := reader.ReadString('\x00')
+			ch <- readResult{data, err}
+		}()
+
+		select {
+		case <-sigCh:
+			fmt.Fprintf(os.Stderr, "golit serve: received signal, shutting down\n")
+			return nil
+		case result := <-ch:
+			if result.err != nil {
+				if result.err == io.EOF {
+					if result.data != "" {
+						input := strings.TrimSpace(result.data)
+						if input != "" {
+							engine := pool.Get()
+							out, _ := transformer.RenderHTMLWithEngine(input, engine, registry, ignored)
+							pool.Put(engine)
+							if _, err := writer.WriteString(out); err != nil {
+								return fmt.Errorf("writing stdout: %w", err)
+							}
+							if err := writer.WriteByte('\x00'); err != nil {
+								return fmt.Errorf("writing stdout: %w", err)
+							}
+							_ = writer.Flush()
+						}
+					}
+					fmt.Fprintf(os.Stderr, "golit serve: stdin closed, shutting down\n")
+					return nil
+				}
+				return fmt.Errorf("reading stdin: %w", result.err)
+			}
+
+			input := strings.TrimSuffix(result.data, "\x00")
+			if input == "" {
+				if err := writer.WriteByte('\x00'); err != nil {
+					return fmt.Errorf("writing stdout: %w", err)
+				}
+				if err := writer.Flush(); err != nil {
+					return fmt.Errorf("flushing stdout: %w", err)
+				}
+				continue
+			}
+
+			start := time.Now()
+			engine := pool.Get()
+			out, renderErr := transformer.RenderHTMLWithEngine(input, engine, registry, ignored)
+			pool.Put(engine)
+			dur := time.Since(start)
+
+			fmt.Fprintf(os.Stderr, "golit serve: render %.1fms\n",
+				float64(dur.Microseconds())/1000.0)
+
+			if renderErr != nil {
+				fmt.Fprintf(os.Stderr, "golit serve: render error: %v\n", renderErr)
+				if err := writer.WriteByte('\x00'); err != nil {
+					return fmt.Errorf("writing stdout: %w", err)
+				}
+				if err := writer.Flush(); err != nil {
+					return fmt.Errorf("flushing stdout: %w", err)
+				}
+				continue
+			}
+
+			if _, err := writer.WriteString(out); err != nil {
+				return fmt.Errorf("writing stdout: %w", err)
+			}
+			if err := writer.WriteByte('\x00'); err != nil {
+				return fmt.Errorf("writing stdout: %w", err)
+			}
+			if err := writer.Flush(); err != nil {
+				return fmt.Errorf("flushing stdout: %w", err)
+			}
+		}
+	}
+}

--- a/cmd/golit/stdio.go
+++ b/cmd/golit/stdio.go
@@ -43,19 +43,23 @@ func runStdio(stdin io.Reader, stdout io.Writer, pool *jsengine.EnginePool, regi
 		case result := <-ch:
 			if result.err != nil {
 				if result.err == io.EOF {
-					if result.data != "" {
-						input := strings.TrimSpace(result.data)
-						if input != "" {
-							engine := pool.Get()
-							out, _ := transformer.RenderHTMLWithEngine(input, engine, registry, ignored)
-							pool.Put(engine)
+					input := strings.TrimSuffix(result.data, "\x00")
+					if input != "" {
+						engine := pool.Get()
+						out, renderErr := transformer.RenderHTMLWithEngine(input, engine, registry, ignored)
+						pool.Put(engine)
+						if renderErr != nil {
+							fmt.Fprintf(os.Stderr, "golit serve: render error: %v\n", renderErr)
+						} else {
 							if _, err := writer.WriteString(out); err != nil {
 								return fmt.Errorf("writing stdout: %w", err)
 							}
-							if err := writer.WriteByte('\x00'); err != nil {
-								return fmt.Errorf("writing stdout: %w", err)
-							}
-							_ = writer.Flush()
+						}
+						if err := writer.WriteByte('\x00'); err != nil {
+							return fmt.Errorf("writing stdout: %w", err)
+						}
+						if err := writer.Flush(); err != nil {
+							return fmt.Errorf("flushing stdout: %w", err)
 						}
 					}
 					fmt.Fprintf(os.Stderr, "golit serve: stdin closed, shutting down\n")

--- a/cmd/golit/stdio_test.go
+++ b/cmd/golit/stdio_test.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zeroedin/golit/pkg/jsengine"
+	"github.com/zeroedin/golit/pkg/transformer"
+)
+
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func buildGolit(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "golit")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = filepath.Join(projectRoot(t), "cmd", "golit")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building golit: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func buildTestBundles(t *testing.T) string {
+	t.Helper()
+	root := projectRoot(t)
+	bundleDir := t.TempDir()
+
+	sources := []string{
+		filepath.Join(root, "testdata", "sources", "my-greeting.js"),
+	}
+
+	nodeModulesDir := jsengine.FindNodeModules(sources[0])
+	externals, err := jsengine.DiscoverExternalPackages(sources, nodeModulesDir)
+	if err != nil {
+		t.Fatalf("discovering externals: %v", err)
+	}
+
+	modules, err := jsengine.BundleComponentModules(sources, jsengine.BundleOptions{
+		ExternalPackages: externals,
+	})
+	if err != nil {
+		t.Fatalf("bundling modules: %v", err)
+	}
+
+	if nodeModulesDir != "" {
+		rt, err := jsengine.BundleSharedRuntime(nodeModulesDir, modules)
+		if err != nil {
+			t.Fatalf("building shared runtime: %v", err)
+		}
+		if err := jsengine.SaveBundle(rt, filepath.Join(bundleDir, "_runtime.golit.module.js")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	modules = jsengine.RewriteModuleImports(modules, externals)
+
+	for srcPath, mod := range modules {
+		base := filepath.Base(srcPath)
+		ext := filepath.Ext(base)
+		outName := strings.TrimSuffix(base, ext) + ".golit.module.js"
+		if err := jsengine.SaveBundle(mod, filepath.Join(bundleDir, outName)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return bundleDir
+}
+
+func buildTestPool(t *testing.T) (*jsengine.EnginePool, *jsengine.Registry) {
+	t.Helper()
+	bundleDir := buildTestBundles(t)
+
+	registry := jsengine.NewRegistry()
+	if err := registry.LoadDir(bundleDir); err != nil {
+		t.Fatalf("loading bundles: %v", err)
+	}
+
+	pool, err := jsengine.NewEnginePool(1)
+	if err != nil {
+		t.Fatalf("creating pool: %v", err)
+	}
+	if err := pool.PreloadAll(registry, nil); err != nil {
+		t.Fatalf("preloading pool: %v", err)
+	}
+
+	return pool, registry
+}
+
+func TestRunStdio_SingleRequest(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	input := "<my-greeting name=\"Stdio\"></my-greeting>\x00"
+	stdin := strings.NewReader(input)
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.HasSuffix(out, "\x00") {
+		t.Fatal("output should end with NUL")
+	}
+	result := strings.TrimSuffix(out, "\x00")
+	if !strings.Contains(result, `shadowrootmode="open"`) {
+		t.Errorf("missing DSD in output:\n%s", result)
+	}
+	if !strings.Contains(result, "Stdio") {
+		t.Errorf("missing name in output:\n%s", result)
+	}
+}
+
+func TestRunStdio_MultipleRequests(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	input := "<my-greeting name=\"First\"></my-greeting>\x00" +
+		"<my-greeting name=\"Second\"></my-greeting>\x00"
+	stdin := strings.NewReader(input)
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	parts := strings.Split(stdout.String(), "\x00")
+	if len(parts) < 3 {
+		t.Fatalf("expected 2 responses, got output: %q", stdout.String())
+	}
+	if !strings.Contains(parts[0], "First") {
+		t.Errorf("first response missing 'First':\n%s", parts[0])
+	}
+	if !strings.Contains(parts[1], "Second") {
+		t.Errorf("second response missing 'Second':\n%s", parts[1])
+	}
+}
+
+func TestRunStdio_EmptyInput(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	stdin := strings.NewReader("\x00")
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	if stdout.String() != "\x00" {
+		t.Errorf("expected bare NUL response, got: %q", stdout.String())
+	}
+}
+
+func TestRunStdio_EOF(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	stdin := strings.NewReader("")
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio should return nil on EOF: %v", err)
+	}
+}
+
+func TestRunStdio_PassthroughHTML(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	input := "<div>no custom elements</div>\x00"
+	stdin := strings.NewReader(input)
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	result := strings.TrimSuffix(stdout.String(), "\x00")
+	if !strings.Contains(result, "no custom elements") {
+		t.Errorf("passthrough HTML should be preserved:\n%s", result)
+	}
+}
+
+func TestRunStdio_IgnoredTags(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	ignored := map[string]bool{"my-greeting": true}
+	input := "<my-greeting name=\"Skip\"></my-greeting>\x00"
+	stdin := strings.NewReader(input)
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, ignored)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	result := strings.TrimSuffix(stdout.String(), "\x00")
+	if strings.Contains(result, `shadowrootmode`) {
+		t.Error("ignored element should not get DSD")
+	}
+}
+
+func TestRunStdio_LargePayload(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	var sb strings.Builder
+	for i := 0; i < 100; i++ {
+		sb.WriteString(`<my-greeting name="Item"></my-greeting>`)
+	}
+	sb.WriteByte('\x00')
+
+	stdin := strings.NewReader(sb.String())
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	result := strings.TrimSuffix(stdout.String(), "\x00")
+	count := strings.Count(result, `shadowrootmode="open"`)
+	if count < 100 {
+		t.Errorf("expected >= 100 DSD templates, got %d", count)
+	}
+}
+
+func TestRunStdio_FullDocument(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	input := "<!DOCTYPE html><html><head><title>Test</title></head><body><my-greeting name=\"Doc\"></my-greeting></body></html>\x00"
+	stdin := strings.NewReader(input)
+	var stdout bytes.Buffer
+
+	err := runStdio(stdin, &stdout, pool, registry, nil)
+	if err != nil {
+		t.Fatalf("runStdio: %v", err)
+	}
+
+	result := strings.TrimSuffix(stdout.String(), "\x00")
+	if !strings.Contains(result, "<title>Test</title>") {
+		t.Errorf("title should be preserved:\n%s", result)
+	}
+	if !strings.Contains(result, `shadowrootmode="open"`) {
+		t.Errorf("missing DSD in output:\n%s", result)
+	}
+}
+
+func TestRunStdio_BrokenStdout(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	input := "<my-greeting name=\"Test\"></my-greeting>\x00"
+	stdin := strings.NewReader(input)
+	w := &brokenWriter{}
+
+	err := runStdio(stdin, w, pool, registry, nil)
+	if err == nil {
+		t.Fatal("expected error on broken stdout")
+	}
+	if !strings.Contains(err.Error(), "stdout") {
+		t.Errorf("expected stdout-related error, got: %v", err)
+	}
+}
+
+type brokenWriter struct{}
+
+func (w *brokenWriter) Write(p []byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+func TestRunStdio_PoolReuse(t *testing.T) {
+	pool, registry := buildTestPool(t)
+	defer pool.Close()
+
+	engine := pool.Get()
+	expected, err := transformer.RenderHTMLWithEngine(
+		`<my-greeting name="Warm"></my-greeting>`, engine, registry, nil)
+	pool.Put(engine)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sb strings.Builder
+	for i := 0; i < 3; i++ {
+		sb.WriteString("<my-greeting name=\"Warm\"></my-greeting>\x00")
+	}
+	stdin := strings.NewReader(sb.String())
+	var stdout bytes.Buffer
+
+	if err := runStdio(stdin, &stdout, pool, registry, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	parts := strings.Split(stdout.String(), "\x00")
+	for i := 0; i < 3; i++ {
+		if parts[i] != expected {
+			t.Errorf("request %d output differs from direct render", i)
+		}
+	}
+}
+
+func TestE2E_ServeStdio(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	cmd := exec.Command(bin, "serve", "--defs", bundleDir, "--stdio")
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting golit serve --stdio: %v", err)
+	}
+	defer func() {
+		stdinPipe.Close()
+		cmd.Wait()
+	}()
+
+	_, err = stdinPipe.Write([]byte("<my-greeting name=\"E2E\"></my-greeting>\x00"))
+	if err != nil {
+		t.Fatalf("writing to stdin: %v", err)
+	}
+
+	result, err := readUntilNUL(t, stdoutPipe)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+
+	if !strings.Contains(result, `shadowrootmode="open"`) {
+		t.Errorf("missing DSD in e2e output:\n%s", result)
+	}
+	if !strings.Contains(result, "E2E") {
+		t.Errorf("missing name in e2e output:\n%s", result)
+	}
+
+	_, err = stdinPipe.Write([]byte("<my-greeting name=\"Again\"></my-greeting>\x00"))
+	if err != nil {
+		t.Fatalf("writing second request: %v", err)
+	}
+
+	result2, err := readUntilNUL(t, stdoutPipe)
+	if err != nil {
+		t.Fatalf("reading second response: %v", err)
+	}
+	if !strings.Contains(result2, "Again") {
+		t.Errorf("missing name in second response:\n%s", result2)
+	}
+
+	stdinPipe.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("process exited with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		cmd.Process.Kill()
+		t.Fatal("process did not exit after stdin closed")
+	}
+}
+
+func TestE2E_ServeStdioMutualExclusion(t *testing.T) {
+	bin := buildGolit(t)
+	bundleDir := buildTestBundles(t)
+
+	cmd := exec.Command(bin, "serve", "--defs", bundleDir, "--stdio", "--listen", "127.0.0.1:9999")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error when --stdio and --listen both set")
+	}
+	if !strings.Contains(string(out), "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' error, got: %s", out)
+	}
+}
+
+func readUntilNUL(t *testing.T, r io.Reader) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	b := make([]byte, 1)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		n, err := r.Read(b)
+		if err != nil {
+			return buf.String(), err
+		}
+		if n > 0 {
+			if b[0] == '\x00' {
+				return buf.String(), nil
+			}
+			buf.WriteByte(b[0])
+		}
+	}
+	return buf.String(), io.ErrNoProgress
+}

--- a/cmd/golit/stdio_test.go
+++ b/cmd/golit/stdio_test.go
@@ -272,10 +272,7 @@ func TestE2E_ServeStdio(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting golit serve --stdio: %v", err)
 	}
-	defer func() {
-		stdinPipe.Close()
-		cmd.Wait()
-	}()
+	defer stdinPipe.Close()
 
 	_, err = stdinPipe.Write([]byte("<my-greeting name=\"E2E\"></my-greeting>\x00"))
 	if err != nil {

--- a/cmd/golit/stdio_test.go
+++ b/cmd/golit/stdio_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"io"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -13,77 +11,6 @@ import (
 	"github.com/zeroedin/golit/pkg/jsengine"
 	"github.com/zeroedin/golit/pkg/transformer"
 )
-
-func projectRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
-
-func buildGolit(t *testing.T) string {
-	t.Helper()
-	name := "golit"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
-	}
-	bin := filepath.Join(t.TempDir(), name)
-	cmd := exec.Command("go", "build", "-o", bin, ".")
-	cmd.Dir = filepath.Join(projectRoot(t), "cmd", "golit")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("building golit: %v\n%s", err, out)
-	}
-	return bin
-}
-
-func buildTestBundles(t *testing.T) string {
-	t.Helper()
-	root := projectRoot(t)
-	bundleDir := t.TempDir()
-
-	sources := []string{
-		filepath.Join(root, "testdata", "sources", "my-greeting.js"),
-	}
-
-	nodeModulesDir := jsengine.FindNodeModules(sources[0])
-	externals, err := jsengine.DiscoverExternalPackages(sources, nodeModulesDir)
-	if err != nil {
-		t.Fatalf("discovering externals: %v", err)
-	}
-
-	modules, err := jsengine.BundleComponentModules(sources, jsengine.BundleOptions{
-		ExternalPackages: externals,
-	})
-	if err != nil {
-		t.Fatalf("bundling modules: %v", err)
-	}
-
-	if nodeModulesDir != "" {
-		rt, err := jsengine.BundleSharedRuntime(nodeModulesDir, modules)
-		if err != nil {
-			t.Fatalf("building shared runtime: %v", err)
-		}
-		if err := jsengine.SaveBundle(rt, filepath.Join(bundleDir, "_runtime.golit.module.js")); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	modules = jsengine.RewriteModuleImports(modules, externals)
-
-	for srcPath, mod := range modules {
-		base := filepath.Base(srcPath)
-		ext := filepath.Ext(base)
-		outName := strings.TrimSuffix(base, ext) + ".golit.module.js"
-		if err := jsengine.SaveBundle(mod, filepath.Join(bundleDir, outName)); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	return bundleDir
-}
 
 func buildTestPool(t *testing.T) (*jsengine.EnginePool, *jsengine.Registry) {
 	t.Helper()

--- a/cmd/golit/stdio_test.go
+++ b/cmd/golit/stdio_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,7 +25,11 @@ func projectRoot(t *testing.T) string {
 
 func buildGolit(t *testing.T) string {
 	t.Helper()
-	bin := filepath.Join(t.TempDir(), "golit")
+	name := "golit"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
 	cmd := exec.Command("go", "build", "-o", bin, ".")
 	cmd.Dir = filepath.Join(projectRoot(t), "cmd", "golit")
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

- Adds `--stdio` flag to `golit serve` that replaces HTTP with a NUL-delimited stdin/stdout protocol
- Same warm engine pool and rendering pipeline — only the transport layer changes
- Mutually exclusive with `--listen`; defaults to 1 engine worker for sequential stdio requests
- Clean shutdown on stdin EOF or SIGTERM (no `/health` endpoint needed — pipe liveness is implicit)

### Protocol

```
stdin:  <html>...</html>\0
stdout: <rendered>...</rendered>\0
```

### Usage

```bash
# Start stdio server
golit serve --defs bundles/ --stdio

# Example: pipe a request
printf '<my-greeting name="World"></my-greeting>\0' | golit serve --defs bundles/ --stdio
```

Relates to #22 — stdio mode closes the gap with lit-ssr-wasm's NUL-delimited protocol while keeping HTTP as the default.

## Test plan

- [x] `TestRunStdio_SingleRequest` — basic component rendering via stdio
- [x] `TestRunStdio_MultipleRequests` — process stays alive across requests
- [x] `TestRunStdio_EmptyInput` — bare NUL returns bare NUL
- [x] `TestRunStdio_EOF` — clean shutdown on stdin close
- [x] `TestRunStdio_PassthroughHTML` — plain HTML passes through unchanged
- [x] `TestRunStdio_IgnoredTags` — `--ignore` works in stdio mode
- [x] `TestRunStdio_LargePayload` — 100 elements in a single request
- [x] `TestRunStdio_FullDocument` — full HTML document rendering
- [x] `TestRunStdio_BrokenStdout` — returns error on broken pipe
- [x] `TestRunStdio_PoolReuse` — warm pool produces consistent output
- [x] `TestE2E_ServeStdio` — full binary integration test with multi-request session
- [x] `TestE2E_ServeStdioMutualExclusion` — `--stdio` + `--listen` rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)